### PR TITLE
Add base auth to lookbook

### DIFF
--- a/app/controllers/lookbook/application_controller.rb
+++ b/app/controllers/lookbook/application_controller.rb
@@ -1,5 +1,7 @@
 module Lookbook
   class ApplicationController < ActionController::Base
+    before_action :base_auth, if: config.base_auth && Rails.env.production?
+
     if respond_to?(:content_security_policy)
       content_security_policy false, if: -> { Rails.env.development? }
     end
@@ -27,6 +29,10 @@ module Lookbook
     end
 
     protected
+
+    def base_auth
+      http_basic_authenticate_with name: ENV['LOOKBOOK_BASE_AUTH_NAME'], password: ENV['LOOKBOOK_BASE_AUTH_PASSWORD']
+    end
 
     def generate_theme_overrides
       @theme_overrides ||= Lookbook.theme.to_css

--- a/lib/lookbook/config.rb
+++ b/lib/lookbook/config.rb
@@ -40,6 +40,8 @@ module Lookbook
         ui_theme_overrides: {},
         ui_favicon: true,
 
+        base_auth: false,
+
         hooks: {
           after_initialize: [],
           before_exit: [],
@@ -58,7 +60,7 @@ module Lookbook
             hotkey: "v",
             panel_classes: "overflow-hidden",
             padded: false,
-            system: true 
+            system: true
           },
           output: {
             pane: :main,


### PR DESCRIPTION
Background:
To give our designers access to lookbook, we activated lookbook in our production environment.
For security reasons, we at least want to provide a base_auth so that not everyone has access to our component library in lookbook.

What was done:
- I added a before_action to the application_controller
- I added a config so that base_auth is deactivated by default