### PR TITLE
Add ability to customize the folder previews appear in

### DIFF
--- a/config/tags.yml
+++ b/config/tags.yml
@@ -27,3 +27,8 @@ shared:
     label: Param
     yard_parser: with_name
     opts: {}
+
+  logical_path:
+    label: Logical path
+    named_args: [logical_path]
+    opts: {}

--- a/docs/src/guide/previews/navigation.md
+++ b/docs/src/guide/previews/navigation.md
@@ -29,6 +29,23 @@ class FooComponentPreview < ViewComponent::Preview
 end
 ```
 
+## Logical Paths
+
+Use the `@logical_path` annotation tag to change the nav folder the preview will appear in.
+
+```ruby
+@logical_path <path>
+```
+
+The `@logical_path` tag can only be used on preview classes:
+
+```ruby
+# @logical_path path/to/my/component
+class FooComponentPreview < ViewComponent::Preview
+  # ...
+end
+```
+
 ## Hiding previews
 
 By default, all previews and examples are shown in the preview navigation.

--- a/lib/lookbook/preview.rb
+++ b/lib/lookbook/preview.rb
@@ -8,7 +8,8 @@ module Lookbook
     def initialize(preview, code_object)
       @preview = preview
       @preview_inspector = SourceInspector.new(code_object, eval_scope: preview_class.new)
-      super(preview_class_path(@preview.name))
+      logical_path = @preview_inspector.tag(:logical_path)&.logical_path
+      super(logical_path || preview_class_path(@preview.name))
     end
 
     def id

--- a/lib/lookbook/stores/tag_store.rb
+++ b/lib/lookbook/stores/tag_store.rb
@@ -39,7 +39,8 @@ module Lookbook
         name: name.to_sym,
         label: opts[:label] || name.to_s.titleize,
         yard_parser: opts[:yard_parser]&.to_sym,
-        opts: opts[:opts].to_h
+        opts: opts[:opts].to_h,
+        named_args: opts[:named_args]
       })
     end
   end

--- a/lib/lookbook/tags.rb
+++ b/lib/lookbook/tags.rb
@@ -6,9 +6,9 @@ module Lookbook
         tag_config = Engine.tags.get_tag(tag_object.tag_name).to_h
         tag_opts = tag_config[:opts].to_h
         Lookbook::Tag.new(tag_object,
-          tag_opts[:named_args],
+          tag_config[:named_args],
           parser: tag_opts[:args_parser],
-          **tag_opts.except(:named_args, :args_parser),
+          **tag_opts.except(:args_parser),
           file: file,
           eval_scope: eval_scope)
       end.compact

--- a/spec/dummy/test/components/previews/annotated_component_preview.rb
+++ b/spec/dummy/test/components/previews/annotated_component_preview.rb
@@ -4,8 +4,9 @@
 # @unregistered this tag is not recognised
 # @custom a custom tag
 # @custom another instance of it
+# @logical_path foo/bar/annotated_component
 class AnnotatedComponentPreview < ViewComponent::Preview
-  
+
   # @id annotated-default
   # @label Annotated Example
   # @hidden

--- a/spec/entities/preview_example_spec.rb
+++ b/spec/entities/preview_example_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe Lookbook::PreviewExample do
       end
     end
 
+    context ".path" do
+      it "uses the logical path" do
+        expect(example.path).to eq "foo/bar/annotated_component/default"
+      end
+    end
+
     context ".tags" do
       it "returns an array of Tag objects" do
         tags = example.tags


### PR DESCRIPTION
The Primer team would like to customize the folder a preview class lives in, a concept I'm calling the "logical path." Right now, the path of the file on disk is used to create a folder hierarchy. This PR introduces a new `@logical_path` tag that overrides the default path with a custom path of your choosing. For example, let's say I'd like to re-scope the `NavList` previews under foo/bar:

```ruby
# @logical_path primer/foo/bar/nav_list
class NavListPreview < ViewComponent::Preview
  # ...
end
```

Here's how it looks:

![image](https://user-images.githubusercontent.com/575280/197647674-ffb19363-d88c-4ae4-8a88-b6c5b42e9b15.png)

It works! 🎉 