### PR TITLE
Add @logical_path tag

### DIFF
--- a/config/tags.yml
+++ b/config/tags.yml
@@ -26,3 +26,7 @@ shared:
   param:
     label: Param
     opts: {}
+
+  logical_path:
+    label: Logical Path
+    opts: {}

--- a/lib/lookbook/preview.rb
+++ b/lib/lookbook/preview.rb
@@ -8,7 +8,14 @@ module Lookbook
     def initialize(preview, code_object)
       @preview = preview
       @preview_inspector = SourceInspector.new(code_object, eval_scope: preview_class.new)
-      super(preview_class_path(@preview.name))
+      preview_path = preview_class_path(name)
+
+      if @preview_inspector.logical_path
+        basename = preview_path.split("/").last
+        preview_path = "#{@preview_inspector.logical_path}/#{basename}"
+      end
+
+      super(preview_path)
     end
 
     def id

--- a/lib/lookbook/source_inspector.rb
+++ b/lib/lookbook/source_inspector.rb
@@ -38,6 +38,11 @@ module Lookbook
       @components ||= Array(code_object.tags(:component)).map(&:value)
     end
 
+    def logical_path
+      path = tag_value(:logical_path)
+      path&.delete_prefix("/")&.delete_suffix("/")
+    end
+
     def display_options
       return @display_options unless @display_options.nil?
 

--- a/lib/lookbook/tags/logical_path.rb
+++ b/lib/lookbook/tags/logical_path.rb
@@ -1,0 +1,4 @@
+module Lookbook
+  class LogicalPathTag < YardTag
+  end
+end

--- a/spec/dummy/test/components/previews/annotated_component_preview.rb
+++ b/spec/dummy/test/components/previews/annotated_component_preview.rb
@@ -3,6 +3,7 @@
 # @unregistered this tag is not recognised
 # @customtag a custom tag
 # @customtag another instance of it
+# @logical_path foo/bar
 class AnnotatedComponentPreview < ViewComponent::Preview
   # @id annotated-default
   # @label Annotated Example

--- a/spec/entities/preview_example_spec.rb
+++ b/spec/entities/preview_example_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe Lookbook::PreviewExample do
       end
     end
 
+    context ".path" do
+      it "uses the logical path" do
+        expect(example.path).to eq "foo/bar/annotated/default"
+      end
+    end
+
     context ".tags" do
       it "returns an array of Tag objects" do
         tags = example.tags

--- a/spec/entities/preview_spec.rb
+++ b/spec/entities/preview_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe Lookbook::Preview do
       end
     end
 
+    context ".path" do
+      it "uses the logical path" do
+        expect(preview.path).to eq "foo/bar/annotated"
+      end
+    end
+
     context ".tags" do
       it "returns an array of Tag objects" do
         tags = preview.tags
@@ -89,7 +95,7 @@ RSpec.describe Lookbook::Preview do
       end
 
       it "includes all the known tags when no type is specified" do
-        expect(preview.tags.size).to eq 4
+        expect(preview.tags.size).to eq 5
       end
 
       it "includes only the matching tags when a type is specified" do

--- a/spec/system/preview_navigation_spec.rb
+++ b/spec/system/preview_navigation_spec.rb
@@ -98,6 +98,11 @@ RSpec.describe "preview navigation", type: :system do
     let(:examples) { preview.examples }
     let(:preview_item_selector) { "#previews-nav-annotated-test" }
 
+    before do
+      click_on("Foo")
+      click_on("Bar")
+    end
+
     context "has preview link" do
       it "with an custom label" do
         expect(page).to have_css(preview_item_selector, text: "Annotated Label")


### PR DESCRIPTION
As per discussion in https://github.com/ViewComponent/lookbook/pull/207 this adds a new tag `@logical_path` which can be used to relocate previews within the nav tree.

The `@logical_path` value should be the path to the nav directory that the preview should be displayed in. The provided path does not have to really exist in the app itself, it is just a virtual construct.

```rb
# @logical_path foo/bar
class Elements::AvatarComponentPreview < ViewComponent::Preview  
 #...
end
```

<img width="262" alt="CleanShot 2022-10-29 at 01 04 15" src="https://user-images.githubusercontent.com/126726/198752262-5de3a309-3110-4aba-83b1-5d715d77e435.png">
