### PR TITLE
Fix split layout and nav item style

### DIFF
--- a/app/components/lookbook/nav/item/component.html.erb
+++ b/app/components/lookbook/nav/item/component.html.erb
@@ -8,7 +8,7 @@
   cloak: true do %>
   <%= lookbook_tag href.present? ? :a : :button,
     href: href,
-    class: "flex items-center py-1 select-none cursor-pointer text-lookbook-nav-text hover:bg-lookbook-nav-item-hover transition",
+    class: "flex w-full items-center py-1 select-none cursor-pointer text-lookbook-nav-text hover:bg-lookbook-nav-item-hover transition",
     style: "padding-left: #{left_pad}px",
     "x-bind": "bindings.#{href.present? ? "link" : "toggle"}" do %>
     <div class="relative flex items-center w-full">

--- a/app/components/lookbook/split_layout/component.html.erb
+++ b/app/components/lookbook/split_layout/component.html.erb
@@ -2,7 +2,7 @@
   <% panes.each.with_index(1) do |pane, i| %>
     <%= pane %>
     <% if i < panes.size %>
-      <div class="bg-lookbook-divider relative" x-init="registerGutter">
+      <div class="bg-lookbook-divider relative z-50" x-init="registerGutter">
         <div class="absolute z-10 bg-transparent hover:bg-lookbook-draggable-hint transition-all" :class="{
           'w-[9px] h-full -translate-x-1/2 cursor-[col-resize]': vertical,
           'h-[9px] w-full -translate-y-1/2 cursor-[row-resize]': horizontal


### PR DESCRIPTION
- Fix `Nav::Item::Component` width.
- Fix `SplitLayout::Component` resize handler `z-index` to be over `Source` panel.