### PR TITLE
Add `@source` tag

### DIFF
--- a/config/tags.yml
+++ b/config/tags.yml
@@ -30,3 +30,7 @@ shared:
   logical_path:
     label: Logical Path
     opts: {}
+
+  source:
+    label: Source file
+    opts: {}

--- a/docs/src/_components/shared/method_info.html.erb
+++ b/docs/src/_components/shared/method_info.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div **html_attrs do %>
   <div class="not-prose">
-    <h3 id="method-<%= name.gsub("_", "-").gsub(".", "") %>" class="font-bold text-lg text-indigo-600">
+    <h3 id="method-<%= name.gsub("_", "-").gsub(".", "").gsub("@", "") %>" class="font-bold text-lg text-indigo-600">
         <%= title %>
     </h3>
   </div>

--- a/docs/src/_data/tags.yml
+++ b/docs/src/_data/tags.yml
@@ -13,7 +13,7 @@ methods:
     purpose: Add a [custom tag](/guide/extend/tags/) for use when annotating component previews
 
 tags:
-  - name: label
+  - name: "@label"
     signature: "@label <text>"
     args:
       - name: <text>
@@ -24,7 +24,7 @@ tags:
       # @label Primary Button
       def main_but
 
-  - name: logical_path
+  - name: "@logical_path"
     signature: "@logical_path <directory_path>"
     args:
       - name: <directory_path>
@@ -37,7 +37,7 @@ tags:
         # ...
       end
 
-  - name: hidden
+  - name: "@hidden"
     signature: "@hidden <value?>"
     args:
       - name: <value?>
@@ -49,7 +49,7 @@ tags:
       # @label hidden
       def not_ready
 
-  - name: group
+  - name: "@!group"
     signature: "@!group <name?> ... @!endgroup"
     args:
       - name: <name?>
@@ -64,7 +64,7 @@ tags:
       end
       # @!endgroup
 
-  - name: param
+  - name: "@param"
     signature: "@param <name> [<type?>] <input_type?> <description?> <opts?>"
     args:
       - name: <name>
@@ -89,14 +89,14 @@ tags:
       # @param theme [Symbol] select { choices: [primary, secondary, danger] }
       def example(theme: :primary)
 
-  - name: display
+  - name: "@display"
     signature: "@display <key> <value>"
     purpose: Sets the value of a [display variable](/guide/previews/display) for use in preview layouts.
     example: |
       # @display bg_color "#000" 
       def light_on_dark
 
-  - name: component
+  - name: "@component"
     signature: "@component <class_name>"
     purpose: |
       Identifies the component being rendered in the preview. Only necessary when it is not possible to guess it from the preview class name.
@@ -106,3 +106,16 @@ tags:
       class InteractiveComponentsPreview < ViewComponent::Preview
     description: |
       Can be applied multiple times if there is more than one component being rendered,
+
+  - name: "@source"
+    signature: "@source <file_path>"
+    args:
+      - name: <file_path>
+        type: String
+        description: |
+          File path. Will be resolved relative to the current preview file if it begins with a "." (i.e. `./component.js`),
+          otherwise it will be resolved relative to the base preview directory
+    purpose: Replace the default content of the 'Source' panel with the contents of the specified file
+    example: |
+      # @source ./component.js
+      def default_example

--- a/lib/lookbook/entities/preview_example.rb
+++ b/lib/lookbook/entities/preview_example.rb
@@ -38,10 +38,6 @@ module Lookbook
       [self]
     end
 
-    def lang
-      Lookbook::Lang.find(:ruby)
-    end
-
     def template_source(template_path)
       source_path = template_file_path(template_path)
       source_path ? File.read(source_path) : nil
@@ -65,6 +61,7 @@ module Lookbook
     end
 
     alias_method :parent, :preview
+    alias_method :lang, :source_lang
 
     protected
 

--- a/lib/lookbook/lang.rb
+++ b/lib/lookbook/lang.rb
@@ -31,6 +31,24 @@ module Lookbook
           ext: ".slim",
           label: "Slim",
           comment: "<!-- %s -->"
+        },
+        {
+          name: "tsx",
+          ext: ".tsx",
+          label: "TypeScript",
+          comment: "// %s"
+        },
+        {
+          name: "js",
+          ext: ".js",
+          label: "JavasScript",
+          comment: "// %s"
+        },
+        {
+          name: "css",
+          ext: ".css",
+          label: "CSS",
+          comment: "/* %s */"
         }
       ]
 
@@ -38,9 +56,10 @@ module Lookbook
         LANGUAGES.find { |l| l[:name] == name.to_s }
       end
 
-      def guess(path)
+      def guess(path, fallback_name = nil)
         ext = File.extname(path)
-        LANGUAGES.find { |l| l[:ext] == ext }
+        lang = LANGUAGES.find { |l| l[:ext] == ext }
+        lang || (find(fallback_name) if fallback_name)
       end
     end
   end

--- a/lib/lookbook/rendered_example.rb
+++ b/lib/lookbook/rendered_example.rb
@@ -15,7 +15,7 @@ module Lookbook
     end
 
     def source_lang
-      has_custom_template? ? template_lang(template) : example.lang
+      has_custom_template? ? template_lang(template) : example.source_lang
     end
 
     protected

--- a/lib/lookbook/services/data/resolvers/data_resolver.rb
+++ b/lib/lookbook/services/data/resolvers/data_resolver.rb
@@ -11,8 +11,8 @@ module Lookbook
       @permit_eval = permit_eval
       @fail_silently = fail_silently
       @fallback = fallback
-      @base_dir = base_dir
-      @file = file
+      @base_dir = base_dir.to_s
+      @file = file.to_s
     end
 
     def call

--- a/lib/lookbook/tags/source_tag.rb
+++ b/lib/lookbook/tags/source_tag.rb
@@ -1,0 +1,7 @@
+module Lookbook
+  class SourceTag < YardTag
+    def value
+      resolve_path(text.strip) if text.present?
+    end
+  end
+end

--- a/spec/dummy/test/components/previews/custom_source_component_preview.rb
+++ b/spec/dummy/test/components/previews/custom_source_component_preview.rb
@@ -1,0 +1,8 @@
+class CustomSourceComponentPreview < ViewComponent::Preview
+  # @source ./nested/my_component/component.js
+  def default
+    render StandardComponent.new do
+      "standard component content"
+    end
+  end
+end

--- a/spec/dummy/test/components/previews/nested/my_component/component.js
+++ b/spec/dummy/test/components/previews/nested/my_component/component.js
@@ -1,0 +1,1 @@
+export default {}

--- a/spec/lib/tags/source_tag_spec.rb
+++ b/spec/lib/tags/source_tag_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Lookbook::SourceTag do
+  let(:host_object) do
+    OpenStruct.new(files: [
+      [Rails.root.join("test/components/previews/nested/my_component/preview.rb"), 1]
+    ])
+  end
+
+  let(:resolved_path) { Rails.root.join("test/components/previews/nested/my_component/component.js") }
+
+  it "extends Lookbook::YardTag" do
+    expect(described_class).to be < Lookbook::YardTag
+  end
+
+  context "file-relative source path" do
+    let(:tag) { described_class.new("./component.js") }
+
+    context ".value" do
+      it "returns the resolved path" do
+        expect(tag).to receive(:object).at_least(:once).and_return(host_object)
+        expect(tag.value).to eq resolved_path
+        expect(tag.value).to be_a Pathname
+      end
+    end
+  end
+
+  context "base-relative source path" do
+    let(:tag) { described_class.new("nested/my_component/component.js") }
+
+    context ".value" do
+      it "returns the resolved path" do
+        expect(tag).to receive(:object).at_least(:once).and_return(host_object)
+        expect(tag.value).to eq resolved_path
+        expect(tag.value).to be_a Pathname
+      end
+    end
+  end
+end

--- a/spec/system/output_panel_spec.rb
+++ b/spec/system/output_panel_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "Output panel", type: :system do
+  context "multi-line tags" do
+    it "does not raise an exception" do
+      visit lookbook_inspect_path("multiline_tag")
+
+      click_on("HTML")
+
+      expect(page).to have_css "#panel-output .code"
+    end
+  end
+end

--- a/spec/system/source_panel_spec.rb
+++ b/spec/system/source_panel_spec.rb
@@ -1,13 +1,15 @@
 require "rails_helper"
 
-RSpec.describe "Output panel", type: :system do
-  context "multi-line tags" do
-    it "does not raise an exception" do
-      visit lookbook_inspect_path("multiline_tag")
+RSpec.describe "Source panel", type: :system do
+  context "custom source file provided by @source tag" do
+    it "renders the file contents" do
+      visit lookbook_inspect_path("custom_source")
 
-      click_on("HTML")
+      click_on("Source")
 
-      expect(page).to have_css "#panel-output .code"
+      within("#panel-source .code") do
+        expect(page).to have_content "export default {}"
+      end
     end
   end
 end


### PR DESCRIPTION
The `@source` tag allows users to override the contents of the `Source` tab by providing a path to a file whose content should be used instead.

The path will be resolved relative to...
* ... the **preview file** that the tag is defined in if it begins with a dot (e.g. `./component.js`)
* ... the **preview base directory** for all other paths.

```ruby
class Frontend::ExampleComponentPreview
  # @source ./example_one.js
  def example_one
  end

  # @source frontend/example_two.html
  def example_two
  end
end
```