### PR TITLE
Fix toggle input attribute-encoding issue  

### DIFF
--- a/app/components/lookbook/params/field/component.rb
+++ b/app/components/lookbook/params/field/component.rb
@@ -34,7 +34,7 @@ module Lookbook
           value: param.value,
           value_type: param.value_type,
           value_default: param.value_default,
-          input_options: input_options.except(:choices),
+          input_options: input_options.except(:choices, :opts),
           choices: input_options[:choices])
       end
 

--- a/app/views/lookbook/inspector/inputs/_toggle.html.erb
+++ b/app/views/lookbook/inspector/inputs/_toggle.html.erb
@@ -11,10 +11,10 @@ span_classes = [
 ]
 %>
 
-<%= button_tag **input_options,
+<%= tag.button **input_options,
   class: class_names(button_classes),
   role: "switch",
   type: "button",
-  "@click.stop": "value = value == 'true' ? 'false' : 'true'" do %>
+  "@click.stop": "value = value == 'true' ? 'false' : 'true'", escape: false do %>
   <%= tag.span "aria-hidden": true, class: class_names(span_classes) %>
 <% end %>


### PR DESCRIPTION
Fixes an issue (#233) where the toggle input was completely unresponsive on some setups due to some over-zealous attribute encoding effectively disabling the AlpineJS `@click` handler.

Many thanks to @jacob-carlborg-apoex for his help in tracking this one down 👍