### PR TITLE
Performance improvements

### DIFF
--- a/app/components/lookbook/nav/component.rb
+++ b/app/components/lookbook/nav/component.rb
@@ -12,7 +12,7 @@ module Lookbook
     end
 
     def items
-      tree.map do |node|
+      @items ||= tree.map do |node|
         item_class = (node.type == :directory) ? Nav::Directory::Component : Nav::Entity::Component
         lookbook_render item_class.new node, nav_id: id
       end

--- a/app/views/layouts/lookbook/application.html.erb
+++ b/app/views/layouts/lookbook/application.html.erb
@@ -1,60 +1,62 @@
 <% content_for :shell do %>
   <% if @previews.any? || @pages.any? %>
-    <%= lookbook_render :split_layout,
-      alpine_data: "$store.layout.main",
-      ":class": "$store.layout.mobile && '!block'" do |layout| %>
+    <% cache do %>
+      <%= lookbook_render :split_layout,
+        alpine_data: "$store.layout.main",
+        ":class": "$store.layout.mobile && '!block'" do |layout| %>
 
-      <% layout.pane id: "app-sidebar", class: "flex flex-col bg-lookbook-sidebar-bg relative translate-x-0",
-        ":class": "{
-          'transition': $store.layout.mobile,
-          'translate-x-full': $store.layout.mobile && sidebarHidden,
-          '!absolute right-0 bottom-0 top-[40px] h-[calc(100%_-_40px)] w-full max-w-[420px] z-50 border-l border-lookbook-divider': $store.layout.mobile
-        }",
-        "@click.outside": "closeMobileSidebar",
-        cloak: true do %>
+        <% layout.pane id: "app-sidebar", class: "flex flex-col bg-lookbook-sidebar-bg relative translate-x-0",
+          ":class": "{
+            'transition': $store.layout.mobile,
+            'translate-x-full': $store.layout.mobile && sidebarHidden,
+            '!absolute right-0 bottom-0 top-[40px] h-[calc(100%_-_40px)] w-full max-w-[420px] z-50 border-l border-lookbook-divider': $store.layout.mobile
+          }",
+          "@click.outside": "closeMobileSidebar",
+          cloak: true do %>
 
-        <%= lookbook_render :split_layout,
-          alpine_data: "$store.layout.#{@pages.any? && @previews.any? ? "sidebar" : "singleSectionSidebar"}",
-          style: "height: calc(100vh - 2.5rem);" do |layout| %>
+          <%= lookbook_render :split_layout,
+            alpine_data: "$store.layout.#{@pages.any? && @previews.any? ? "sidebar" : "singleSectionSidebar"}",
+            style: "height: calc(100vh - 2.5rem);" do |layout| %>
 
-          <% if @previews.any? %>
-            <% layout.pane class: "overflow-hidden" do %>
-              <%= lookbook_render :nav,
-                id: "previews-nav",
-                tree: @previews.to_tree,
-                alpine_data: "$store.nav.previews" do |nav| %>
-                <%= nav.toolbar do |toolbar| %>
-                  <% toolbar.section padded: true do %>
-                    <h4 class="pt-1">Previews</h4>
-                  <% end %>
-                  <% toolbar.section align: :right, padded: false do %>
-                    <%= lookbook_render :button_group, size: :xs do |group| %>
-                      <% group.button icon: :minus_square,
-                        tooltip: "Collapse all",
-                        "@click": "closeAll" %>
+            <% if @previews.any? %>
+              <% layout.pane class: "overflow-hidden" do %>
+                <%= lookbook_render :nav,
+                  id: "previews-nav",
+                  tree: @previews.to_tree,
+                  alpine_data: "$store.nav.previews" do |nav| %>
+                  <%= nav.toolbar do |toolbar| %>
+                    <% toolbar.section padded: true do %>
+                      <h4 class="pt-1">Previews</h4>
+                    <% end %>
+                    <% toolbar.section align: :right, padded: false do %>
+                      <%= lookbook_render :button_group, size: :xs do |group| %>
+                        <% group.button icon: :minus_square,
+                          tooltip: "Collapse all",
+                          "@click": "closeAll" %>
+                      <% end %>
                     <% end %>
                   <% end %>
+                  <% nav.filter store: "$store.nav.previews.filter", placeholder: "Filter previews by name&hellip;" %>
                 <% end %>
-                <% nav.filter store: "$store.nav.previews.filter", placeholder: "Filter previews by name&hellip;" %>
               <% end %>
             <% end %>
-          <% end %>
 
-          <% if @pages.any? %>
-            <% layout.pane class: "overflow-hidden" do %>
-              <%= lookbook_render :nav,
-                id: "pages-nav",
-                tree: @pages.to_tree,
-                alpine_data: "$store.nav.pages" do |nav| %>
-                <%= nav.toolbar do |toolbar| %>
-                  <% toolbar.section padded: true do %>
-                    <h4 class="pt-1">Pages</h4>
-                  <% end %>
-                  <% toolbar.section align: :right, padded: false do %>
-                    <%= lookbook_render :button_group, size: :xs do |group| %>
-                      <% group.button icon: :minus_square,
-                        tooltip: "Collapse all",
-                        "@click": "closeAll" %>
+            <% if @pages.any? %>
+              <% layout.pane class: "overflow-hidden" do %>
+                <%= lookbook_render :nav,
+                  id: "pages-nav",
+                  tree: @pages.to_tree,
+                  alpine_data: "$store.nav.pages" do |nav| %>
+                  <%= nav.toolbar do |toolbar| %>
+                    <% toolbar.section padded: true do %>
+                      <h4 class="pt-1">Pages</h4>
+                    <% end %>
+                    <% toolbar.section align: :right, padded: false do %>
+                      <%= lookbook_render :button_group, size: :xs do |group| %>
+                        <% group.button icon: :minus_square,
+                          tooltip: "Collapse all",
+                          "@click": "closeAll" %>
+                      <% end %>
                     <% end %>
                   <% end %>
                 <% end %>
@@ -62,10 +64,10 @@
             <% end %>
           <% end %>
         <% end %>
-      <% end %>
 
-      <% layout.pane id: "app-main", class: "overflow-hidden h-full", ":class": "$store.layout.mobile && 'w-screen'" do %>
-        <%= content_for?(:main) ? yield(:main) : yield %>
+        <% layout.pane id: "app-main", class: "overflow-hidden h-full", ":class": "$store.layout.mobile && 'w-screen'" do %>
+          <%= content_for?(:main) ? yield(:main) : yield %>
+        <% end %>
       <% end %>
     <% end %>
   <% else %>


### PR DESCRIPTION
We use lookbook in production as a documentation website for [Polaris ViewComponents](https://polarisviewcomponents.org). The loading time on production was pretty slow (2-3 seconds for the initial inspector load). After diving into the problem I noticed that the main source of the issue is sidebar generation. It was called 3 times for each request and generation itself takes some time for a large preview list. To optimize this I made two changes:

1. Added memoization for tree generation in the Nav component. It's called 3 times per request so it's a big win in development mode.
2. I added caching for the whole lookbook sidebar. It makes loading fast on production as we don't need to regenerate the tree each time.