### PR TITLE
chore: Require Ruby version 2.7 or higher

### DIFF
--- a/lookbook.gemspec
+++ b/lookbook.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,lib,public}/**/*", "LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.7.0"
+
   spec.add_dependency "css_parser"
   spec.add_dependency "actioncable"
   spec.add_dependency "activemodel"


### PR DESCRIPTION
Lookbook isn't compatible with apps running Ruby < 2.7 so we should update the gemspec to reflect that. At present you can install lookbook in an app running <2.7 without any bundler errors but will cause booting the app to fail. Updating the gemspec will stop people with unsupported ruby versions from installing in the first place.