### PR TITLE
Remove redundant `Utils` include

### DIFF
--- a/app/helpers/lookbook/page_helper.rb
+++ b/app/helpers/lookbook/page_helper.rb
@@ -1,7 +1,5 @@
 module Lookbook
   module PageHelper
-    include Utils
-
     def page_path(id)
       page = id.is_a?(Page) ? id : Lookbook.pages.find_by_id(id)
       if page.present?


### PR DESCRIPTION
The `include Utils` line in `PageHelper` seems to be a leftover from a refactor. The `Utils` module has no methods of its own, only its singleton class has methods. So including `Utils` into any class will not have any effect, which makes this include redundant.