### PR TITLE
Link to official Rails docs instead of apidock

### DIFF
--- a/docs/src/guide/previews/display.md
+++ b/docs/src/guide/previews/display.md
@@ -108,7 +108,7 @@ config.lookbook.preview_display_options = {
 }
 ```
 
-The array of option choices will be passed through Rails' [`options_for_select` helper](https://apidock.com/rails/v6.1.3.1/ActionView/Helpers/FormOptionsHelper/options_for_select) to generate the select dropdown options.
+The array of option choices will be passed through Rails' [`options_for_select` helper](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-options_for_select) to generate the select dropdown options.
 
 The display option value can then be accessed in layout templates in exactly the same way as 'regular' display options:
 


### PR DESCRIPTION
apidock is out-of-date, it only goes up to Rails 6.1.3.1 which was released in 2021, much better to link directly to the latest official Rails docs.