### PR TITLE
Add `title` to `iframe` in `Viewport::Component`

### DIFF
--- a/app/components/lookbook/viewport/component.html.erb
+++ b/app/components/lookbook/viewport/component.html.erb
@@ -32,7 +32,8 @@
         style="<%= "max-height: #{@max_height}px;" if @max_height.present? %>"
         src="<%= @src %>"
         frameborder="0"
-        @load="$dispatch('viewport:loaded', {viewport: this})"></iframe>
+        @load="$dispatch('viewport:loaded', {viewport: this})"
+        title="viewport"></iframe>
         <% if @resize_width %>
           <div
             class="resize-handle border-r border-t border-lookbook-divider cursor-[col-resize] <%= "border-b" unless @resize_height %>"


### PR DESCRIPTION
I'm working on a panel that runs axe tests on the preview. To accomplish this, I pass the `iframe` element to `axe.run`. Currently this always produces a violation because the iframe is missing a `title` (see https://dequeuniversity.com/rules/axe/4.6/frame-title). This will let me avoid having to filter out the violation and it improves Lookbook's accessibility (which I gotta say isn't great at the moment, a lot of unlabelled buttons).