### PR TITLE
Add JSON endpoint for listing previews and examples

### DIFF
--- a/app/controllers/lookbook/application_controller.rb
+++ b/app/controllers/lookbook/application_controller.rb
@@ -17,6 +17,7 @@ module Lookbook
 
     def index
       landing = Lookbook.pages.find(&:landing?) || Lookbook.pages.first
+
       if landing.present?
         redirect_to lookbook_page_path(landing.path)
       else

--- a/app/controllers/lookbook/previews_controller.rb
+++ b/app/controllers/lookbook/previews_controller.rb
@@ -10,6 +10,26 @@ module Lookbook
       "lookbook/previews"
     end
 
+    def index
+      respond_to do |format|
+        format.json do
+          render(
+            json: Lookbook.previews.map do |preview|
+              {
+                name: preview.name,
+                examples: preview.examples.map { |example|
+                  {
+                    inspect_path: example.url_path,
+                    name: example.name
+                  }
+                }
+              }
+            end
+          )
+        end
+      end
+    end
+
     def show
       if @target
         begin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Lookbook::Engine.routes.draw do
   get "/#{Lookbook.config.page_route}", to: "pages#index", as: :lookbook_page_index
   get "/#{Lookbook.config.page_route}/*path", to: "pages#show", as: :lookbook_page
 
+  get "/previews", to: "previews#index", as: :lookbook_previews
   get "/preview/*path", to: "previews#show", as: :lookbook_preview
   get "/inspect/*path", to: "inspector#show", as: :lookbook_inspect
 

--- a/docs/src/api/json_endpoints.md
+++ b/docs/src/api/json_endpoints.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: JSON Endpoints
+---
+
+Lookbook currently implements a single JSON endpoint at `/previews.json`, returning previews and their examples:
+
+```ruby
+[{
+  "name" => "annotated",
+  "examples" =>
+    [
+      {
+        "name" => "default",
+        "inspect_path" => "/lookbook/inspect/foo/bar/annotated/default"
+      }
+    ]
+}]
+```

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -75,4 +75,18 @@ RSpec.describe "application", type: :request do
       end
     end
   end
+
+  context "JSON endpoint" do
+    it "returns a JSON list of previews with example inspect paths" do
+      get lookbook_previews_path(format: :json)
+
+      parsed_response = JSON.parse(response.body)
+
+      expect(
+        parsed_response
+          .find { |item| item["name"] == "annotated" }["examples"]
+          .find { |item| item["name"] == "default" }["inspect_path"]
+      ).to eq("/lookbook/inspect/foo/bar/annotated/default")
+    end
+  end
 end

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "application", type: :request do
     end
   end
 
-  context "JSON endpoint" do
+  describe "JSON endpoint" do
     it "returns a JSON list of previews with example inspect paths" do
       get lookbook_previews_path(format: :json)
 


### PR DESCRIPTION
This change introduces a JSON endpoint that returns a machine-readable representation of the previews and examples served by Lookbook.

I'm introducing this feature so that Lookbook deployments can be crawled by our automated tooling at GitHub.