### PR TITLE
Stop sending `X-Frame-Options`

### DIFF
--- a/app/controllers/lookbook/previews_controller.rb
+++ b/app/controllers/lookbook/previews_controller.rb
@@ -3,6 +3,8 @@ module Lookbook
     include TargetableConcern
     include WithPreviewControllerConcern
 
+    before_action { response.headers.delete('X-Frame-Options') }
+
     layout "lookbook/inspector"
     helper Lookbook::PreviewHelper
 


### PR DESCRIPTION
Oftentimes, applications will customize [`X-Frame-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) via `config.action_dispatch.default_headers`, setting it to `DENY` (similar to the `frame-ancestors` CSP directive). While a pretty good idea for most applications, Lookbook depends on rendering within an iframe, and so should not include that header!

This is similar to Lookbook not including `Content-Security-Policy`.