### PR TITLE
Update notes panel partial prose container to h-auto

### DIFF
--- a/app/views/lookbook/inspector/panels/_notes.html.erb
+++ b/app/views/lookbook/inspector/panels/_notes.html.erb
@@ -11,7 +11,7 @@
     <% end %>
   </div>
 <% else %>
-  <div class="p-4 w-full h-full bg-lookbook-prose-bg">
+  <div class="p-4 w-full h-auto bg-lookbook-prose-bg">
     <%= lookbook_render :prose do %>
       <%== items.any? ? items.first.notes : "<em class='opacity-50'>No notes provided.</em>" %>
     <% end %>


### PR DESCRIPTION
The notes panel has an inconsistent background color when the notes content is longer than the panel's initial display height because the container that wraps the notes prose content is set to `h-full`. Setting it to `h-auto` fixes it. 

**Broken Background**

![image](https://user-images.githubusercontent.com/4515/215268194-c7596172-892d-4a1a-9163-5beb27d533ab.png)

Notice the white background of the notes doesn't fill the space where the panel needed to be scrolled.

**Fixed Background**

![image](https://user-images.githubusercontent.com/4515/215268236-57ed737f-ded6-4565-83a4-ba33b8bc0420.png)

I can't think of any danger to this change.

<3 

