### PR TITLE
Expire fragment cache after changes

### DIFF
--- a/app/views/layouts/lookbook/application.html.erb
+++ b/app/views/layouts/lookbook/application.html.erb
@@ -13,7 +13,7 @@
         }",
         "@click.outside": "closeMobileSidebar",
         cloak: true do %>
-        <% cache do %>
+        <% cache Lookbook::Engine.last_changed do %>
           <%= lookbook_render :split_layout,
             alpine_data: "$store.layout.#{@pages.any? && @previews.any? ? "sidebar" : "singleSectionSidebar"}",
             style: "height: calc(100vh - 2.5rem);" do |layout| %>


### PR DESCRIPTION
Implements a pretty crude fragment cache expiration strategy to help fix the issue outlined in #303 whereby enabling Rails' cache in development prevents Lookbook's nav from updating after changes.

