### PR TITLE
add preview_path to JSON endpoint

### DIFF
--- a/app/controllers/lookbook/previews_controller.rb
+++ b/app/controllers/lookbook/previews_controller.rb
@@ -20,10 +20,15 @@ module Lookbook
               {
                 name: preview.name,
                 examples: preview.examples.map { |example|
-                  {
-                    inspect_path: example.url_path,
-                    name: example.name
-                  }
+                  case example
+                  when Lookbook::PreviewExample
+                    example_json(example)
+                  when Lookbook::PreviewGroup
+                    {
+                      name: example.name,
+                      examples: example.examples.map { |ex| example_json(ex) }
+                    }
+                  end
                 }
               }
             end
@@ -49,6 +54,16 @@ module Lookbook
       else
         show_404 layout: "lookbook/standalone"
       end
+    end
+
+    private
+
+    def example_json(example)
+      {
+        inspect_path: example.url_path,
+        name: example.name,
+        preview_path: example.preview_path
+      }
     end
   end
 end

--- a/app/controllers/lookbook/previews_controller.rb
+++ b/app/controllers/lookbook/previews_controller.rb
@@ -62,7 +62,8 @@ module Lookbook
       {
         inspect_path: example.url_path,
         name: example.name,
-        preview_path: example.preview_path
+        preview_path: example.preview_path,
+        lookup_path: example.lookup_path
       }
     end
   end

--- a/docs/src/api/json_endpoints.md
+++ b/docs/src/api/json_endpoints.md
@@ -12,7 +12,8 @@ Lookbook currently implements a single JSON endpoint at `/previews.json`, return
     [
       {
         "name" => "default",
-        "inspect_path" => "/lookbook/inspect/foo/bar/annotated/default"
+        "inspect_path" => "/lookbook/inspect/foo/bar/annotated/default",
+        "preview_path" => "/lookbook/preview/foo/bar/annotated/default"
       }
     ]
 }]

--- a/lib/lookbook/entities/preview_example.rb
+++ b/lib/lookbook/entities/preview_example.rb
@@ -57,6 +57,10 @@ module Lookbook
       lookbook_inspect_path(path)
     end
 
+    def preview_path
+      lookbook_preview_path(path)
+    end
+
     def type
       :example
     end

--- a/lib/lookbook/entities/preview_group.rb
+++ b/lib/lookbook/entities/preview_group.rb
@@ -39,6 +39,10 @@ module Lookbook
       lookbook_inspect_path(path)
     end
 
+    def preview_path
+      lookbook_preview_path(path)
+    end
+
     def type
       :group
     end

--- a/spec/entities/preview_example_spec.rb
+++ b/spec/entities/preview_example_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Lookbook::PreviewExample do
       end
     end
 
+    context ".preview_path" do
+      it "returns the URL to the isolated preview" do
+        expect(example.preview_path).to eq lookbook_preview_path("standard/default")
+      end
+
+      it "is a String" do
+        expect(example.preview_path).to be_a String
+      end
+    end
+
     context ".source" do
       it "returns the example method source code" do
         source_lines = example.source.split("\n")

--- a/spec/entities/preview_group_spec.rb
+++ b/spec/entities/preview_group_spec.rb
@@ -34,8 +34,14 @@ RSpec.describe Lookbook::PreviewGroup do
     end
 
     context ".url_path" do
-      it "returns the expected preview group URL" do
+      it "returns the expected inspector URL" do
         expect(group.url_path).to eq lookbook_inspect_path("group/groups")
+      end
+    end
+
+    context ".preview_path" do
+      it "returns the expected preview URL" do
+        expect(group.preview_path).to eq lookbook_preview_path("group/groups")
       end
     end
   end
@@ -46,6 +52,12 @@ RSpec.describe Lookbook::PreviewGroup do
     context ".url_path" do
       it "returns the expected preview group URL" do
         expect(group.url_path).to eq lookbook_inspect_path("group/named")
+      end
+    end
+
+    context ".preview_path" do
+      it "returns the expected preview URL" do
+        expect(group.preview_path).to eq lookbook_preview_path("group/named")
       end
     end
   end

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -77,22 +77,26 @@ RSpec.describe "application", type: :request do
   end
 
   describe "JSON endpoint" do
-    it "returns a JSON list of previews with example paths" do
+    it "returns a JSON list of previews" do
       get lookbook_previews_path(format: :json)
 
       parsed_response = JSON.parse(response.body)
 
+      default_preview = parsed_response
+        .find { |item| item["name"] == "annotated" }["examples"]
+        .find { |item| item["name"] == "default" }
+
       expect(
-        parsed_response
-          .find { |item| item["name"] == "annotated" }["examples"]
-          .find { |item| item["name"] == "default" }["inspect_path"]
+        default_preview["inspect_path"]
       ).to eq("/lookbook/inspect/foo/bar/annotated/default")
 
       expect(
-        parsed_response
-          .find { |item| item["name"] == "annotated" }["examples"]
-          .find { |item| item["name"] == "default" }["preview_path"]
+        default_preview["preview_path"]
       ).to eq("/lookbook/preview/foo/bar/annotated/default")
+
+      expect(
+        default_preview["lookup_path"]
+      ).to eq("foo/bar/annotated/default")
     end
   end
 end

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "application", type: :request do
   end
 
   describe "JSON endpoint" do
-    it "returns a JSON list of previews with example inspect paths" do
+    it "returns a JSON list of previews with example paths" do
       get lookbook_previews_path(format: :json)
 
       parsed_response = JSON.parse(response.body)
@@ -87,6 +87,12 @@ RSpec.describe "application", type: :request do
           .find { |item| item["name"] == "annotated" }["examples"]
           .find { |item| item["name"] == "default" }["inspect_path"]
       ).to eq("/lookbook/inspect/foo/bar/annotated/default")
+
+      expect(
+        parsed_response
+          .find { |item| item["name"] == "annotated" }["examples"]
+          .find { |item| item["name"] == "default" }["preview_path"]
+      ).to eq("/lookbook/preview/foo/bar/annotated/default")
     end
   end
 end


### PR DESCRIPTION
## Problem

I'd like to expose the preview_path for previews in the JSON endpoint I recently added.

## Proposed solution

Add a `preview_path` method to `Lookbook::Preview` and expose it via the API. I also exposed `lookup_path`. 

Note that in doing this I realized that the API does not handle preview groups, so I added some basic support for them here. @allmarkedup is infinite nesting allowed for preview groups? If so, we likely need to rethink this API entirely.

This controller method is getting a little messy. While I don't think we need to refactor it now, I think we're on the path towards needing a serializer or something similar.