### PR TITLE
Allow preview embeds to be disabled

### DIFF
--- a/app/views/lookbook/inspector/show.html.erb
+++ b/app/views/lookbook/inspector/show.html.erb
@@ -33,13 +33,15 @@
 
         <% toolbar.with_section divide: :left, class: "flex-none relative z-10" do %>
           <%= lookbook_render :button_group do |group| %>
-            <%= group.with_button id: "embed-generator-dropdown-button", icon: :code_2, tooltip: "Get embed code" do |button| %>
-              <% button.with_dropdown.with_content(lookbook_render :embed_code_dropdown,
-                pages: @pages,
-                preview: @preview,
-                target: @target,
-                params: request.query_parameters
-              ) %>
+            <% if Lookbook.config.preview_embeds.enabled %>
+              <%= group.with_button id: "embed-generator-dropdown-button", icon: :code_2, tooltip: "Get embed code" do |button| %>
+                <% button.with_dropdown.with_content(lookbook_render :embed_code_dropdown,
+                  pages: @pages,
+                  preview: @preview,
+                  target: @target,
+                  params: request.query_parameters
+                ) %>
+              <% end %>
             <% end %>
             <% group.with_button id: "copy-preview-url-button",
               icon: :link,

--- a/config/app.yml
+++ b/config/app.yml
@@ -9,6 +9,7 @@ shared:
     main_panels: [preview, output]
     drawer_panels: [source, notes, params, "*"]
   preview_embeds:
+    enabled: true
     policy: "SAMEORIGIN"
     panels: false
     actions: []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Lookbook::Engine.routes.draw do
 
   get "/inspect/*path", to: "inspector#show", as: :lookbook_inspect
 
-  get "/embed", to: "embeds#lookup", as: :lookbook_embed_lookup
-  get "/embed/*path", to: "embeds#show", as: :lookbook_embed
+  if Lookbook.config.preview_embeds.enabled
+    get "/embed", to: "embeds#lookup", as: :lookbook_embed_lookup
+    get "/embed/*path", to: "embeds#show", as: :lookbook_embed
+  end
 end

--- a/docs/src/_data/config_options.yml
+++ b/docs/src/_data/config_options.yml
@@ -34,6 +34,12 @@ previews:
     example: config.lookbook.preview_inspector.drawer_panels = [:notes, :params]
     description: List of panels to display in the preview inspector
 
+  - name: preview_embeds.enabled
+    types: Boolean
+    default: "true"
+    example: config.lookbook.preview_embeds.enabled = false
+    description: Whether or not preview embeds are enabled.
+
   - name: preview_embeds.policy
     types: String
     default: SAMEORIGIN

--- a/docs/src/_guide/sharing/embeds.md
+++ b/docs/src/_guide/sharing/embeds.md
@@ -242,3 +242,14 @@ lookbook_embeds: true
     Once set, only embeds that wish to override the defaults need specify these as attributes.
   <% end %>
 <% end %>
+
+<%= render section("Disable embeds", id: "disable-embeds") do |s| %>
+  <% s.with_block_prose do %>
+    If you do not want to support embeds at all, you can disable them completely.
+
+    ```rb
+    # config/application.rb
+    config.lookbook.preview_embeds.enabled = false
+    ```
+  <% end %>
+<% end %>


### PR DESCRIPTION
While I definitely understand the appeal of the new preview embeds functionality, it would be great if the feature could be disabled in case you don't want to expose that kind of functionality!