### PR TITLE
Updating renders many calls to use with

### DIFF
--- a/app/components/lookbook/page_tabs/component.html.erb
+++ b/app/components/lookbook/page_tabs/component.html.erb
@@ -2,13 +2,13 @@
   <div class="flex w-full border-b border-lookbook-divider mb-6">
     <%= lookbook_render :tabs, theme: :page do |t| %>
       <% @tabs.each do |props| %>
-        <%= t.tab **props %>
+        <%= t.with_tab **props %>
       <% end %>
     <% end %>
   </div>
   <%= lookbook_render :tab_panels do |t| %>
     <% @tabs.each do |props| %>
-      <% t.panel name: props[:name] do %>
+      <% t.with_panel name: props[:name] do %>
         <%= lookbook_render :prose, markdown: props[:markdown], class: "max-w-none flex-none" do %>
           <%== props[:tab_content] %>
         <% end %>

--- a/app/views/lookbook/pages/show.html.erb
+++ b/app/views/lookbook/pages/show.html.erb
@@ -5,11 +5,11 @@
   @dom:update-complete.window="Lookbook.initEmbeds();">
   <div class="h-full bg-lookbook-page-bg relative">
     <% unless @error %>
-      
+
       <div class="absolute top-0 right-0 pt-1 pr-0 pl-1 pb-1 rounded-bl-md">
         <div class="bg-lookbook-page-bg opacity-90 absolute inset-0 w-full h-full z-0"></div>
         <div class="relative z-10 flex items-center">
-        
+
         <% if @previous_page %>
           <%= lookbook_render :icon_button,
             size: :lg,
@@ -58,7 +58,7 @@
         <% if @page.sections.any? %>
           <%= lookbook_render :page_tabs, id: "page-tabbed-sections", markdown: false, class: "mt-6" do |page_tabs| %>
             <% @page.sections.each do |section| %>
-              <% page_tabs.tab name: "page-section-#{section.name}", label: section.label do %>
+              <% page_tabs.with_tab name: "page-section-#{section.name}", label: section.label do %>
                 <%= page_controller.render_page(section) %>
               <% end %>
             <% end %>


### PR DESCRIPTION
v3 of ViewComponent requires `renders_many` slots to use `with_tab` rather than just `tab`. It looks like most (or all) of the other places in the codebase already used `with_` to call, but there were a few places within tabs that didn't.