### PR TITLE
docs: Allow method_list titles to be used as anchors

### DIFF
--- a/docs/src/_components/lookbook_docs/method_list/component.html.erb
+++ b/docs/src/_components/lookbook_docs/method_list/component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.section **html_attrs do %>
   <% if title %>
-    <h2 class="text-xs uppercase tracking-wider mb-4 text-gray-500"><%= title %></h2>
+    <h2 class="text-xs uppercase tracking-wider mb-4 text-gray-500" id="<%= title.parameterize %>"><%= title %></h2>
   <% end %>
   <div class="space-y-6">
     <% items.each do |item| %>


### PR DESCRIPTION
Currently titles in `toc` are clickable, but `method_list` titles do not behave as anchors (they don't have an ID), so nothing happens when you click them.

![image](https://user-images.githubusercontent.com/38524/220191199-4fbf9711-1fc9-45e3-84fe-e5d956c8fab2.png)

![image](https://user-images.githubusercontent.com/38524/220191245-6942b9a8-b3d3-41d5-9e66-1558adaf72bb.png)
