### PR TITLE
Nesting tabs inside page content to fix min height 50vh issue

### DIFF
--- a/app/views/lookbook/pages/show.html.erb
+++ b/app/views/lookbook/pages/show.html.erb
@@ -54,13 +54,13 @@
 
         <%= lookbook_render :prose, size: :md, id: "page-content", markdown: false, class: "max-w-none flex-none min-h-[50vh]" do %>
           <%= @page_content %>
-        <% end %>
 
-        <% if @page.sections.any? %>
-          <%= lookbook_render :page_tabs, id: "page-tabbed-sections", markdown: false, class: "mt-6" do |page_tabs| %>
-            <% @page.sections.each do |section| %>
-              <% page_tabs.with_tab name: "page-section-#{section.name}", label: section.label do %>
-                <%= page_controller.render_page(section) %>
+          <% if @page.sections.any? %>
+            <%= lookbook_render :page_tabs, id: "page-tabbed-sections", markdown: false, class: "mt-6" do |page_tabs| %>
+              <% @page.sections.each do |section| %>
+                <% page_tabs.with_tab name: "page-section-#{section.name}", label: section.label do %>
+                  <%= page_controller.render_page(section) %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>


### PR DESCRIPTION
I noticed when upgrading to v2 there is a large gap between the "page" and the "tabs", and it is due to a min height of 50vh on the page container. I thought the quickest way to fix this would be to move the tabs into the page rather than having them appear after. Screenshots below.

Before change:
![Screen Shot 2023-03-07 at 3 01 30 PM](https://user-images.githubusercontent.com/603921/223546783-5abaa780-4fb2-4617-95b2-27f078505a20.png)

After change:
![Screen Shot 2023-03-07 at 2 57 53 PM](https://user-images.githubusercontent.com/603921/223546822-2a8f8c38-caf4-4ef9-95e1-f2d61b310ba5.png)