### PR TITLE
Use double quotes to fix escape issues

### DIFF
--- a/app/components/lookbook/params/field/component.rb
+++ b/app/components/lookbook/params/field/component.rb
@@ -17,7 +17,7 @@ module Lookbook
         escaped_value = json_escape(param.value.to_s)
         wrapper_attrs = {
           data: {"param-input": param.input},
-          "x-data": "paramsInputComponent({name: '#{param.name}', value: '#{escaped_value}'})"
+          "x-data": "paramsInputComponent({name: \"#{param.name}\", value: \"#{escaped_value}\"})"
         }
         @rendered_input = tag.div(**wrapper_attrs) { html.html_safe }
       end


### PR DESCRIPTION
I ran into an issue where trying to put a paragraph of text including single quotes (`'`) as the default value for a param ended up with the text param showing "undefined" in the UI. Looking into `json_escape`, it is expecting to escape double quotes not single quotes, so I changed the code here to use escaped double quotes instead of single quotes.

Running this locally fixes the issue for me.