### PR TITLE
Preview Output Transformation

### DIFF
--- a/app/views/lookbook/previews/preview.html.erb
+++ b/app/views/lookbook/previews/preview.html.erb
@@ -1,5 +1,11 @@
-<% if @render_args[:component] %>
-  <%= render(@render_args[:component], @render_args[:args], &@render_args[:block]) %>
-<% else %>
-  <%= render(@render_args[:template], **@render_args[:locals], &@render_args[:block]) %>
-<% end %>
+<%=
+  output = if @render_args[:component]
+    render(@render_args[:component], @render_args[:args], &@render_args[:block])
+  else
+    render(@render_args[:template], **@render_args[:locals], &@render_args[:block])
+  end
+
+  output = @render_args[:output_transformer].call(output) if @render_args[:output_transformer]
+
+  output
+%>

--- a/spec/dummy/test/components/previews/partial_example_preview.rb
+++ b/spec/dummy/test/components/previews/partial_example_preview.rb
@@ -6,4 +6,10 @@ class PartialExamplePreview < Lookbook::Preview
   def helpers
     render "partials/helpers_example"
   end
+
+  def transform
+    render_args = render "partials/basic_example"
+    render_args[:output_transformer] = ->(html) { "<span>transformed</span>#{html}".html_safe }
+    render_args
+  end
 end

--- a/spec/dummy/test/components/previews/phlex_example_preview.rb
+++ b/spec/dummy/test/components/previews/phlex_example_preview.rb
@@ -6,4 +6,10 @@ class PhlexExamplePreview < Lookbook::Preview
   def helpers
     render Views::Phlex::HelpersExample.new
   end
+
+  def transform
+    render_args = render Views::Phlex::BasicExample.new
+    render_args[:output_transformer] = ->(html) { "<span>transformed</span>#{html}".html_safe }
+    render_args
+  end
 end

--- a/spec/dummy/test/components/previews/view_component_example_preview.rb
+++ b/spec/dummy/test/components/previews/view_component_example_preview.rb
@@ -2,4 +2,10 @@ class ViewComponentExamplePreview < Lookbook::Preview
   def default
     render BasicComponent.new
   end
+
+  def transform
+    render_args = render BasicComponent.new
+    render_args[:output_transformer] = ->(html) { "<span>transformed</span>#{html}".html_safe }
+    render_args
+  end
 end

--- a/spec/requests/previews_spec.rb
+++ b/spec/requests/previews_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe "previews", type: :request do
 
       expect(html).to have_content "viewcomponent component"
     end
+
+    it "supports output transformation" do
+      get lookbook_preview_path("view_component_example/transform")
+
+      expect(html.has_css?("span", text: "transformed")).to be true
+    end
   end
 
   if AppHelper.phlexible?
@@ -22,6 +28,12 @@ RSpec.describe "previews", type: :request do
 
         expect(html).to have_content "http://localhost/"
       end
+
+      it "supports output transformation" do
+        get lookbook_preview_path("phlex_example/transform")
+
+        expect(html.has_css?("span", text: "transformed")).to be true
+      end
     end
   end
 
@@ -36,6 +48,12 @@ RSpec.describe "previews", type: :request do
       get lookbook_preview_path("partial_example/helpers")
 
       expect(html).to have_content "http://localhost/"
+    end
+
+    it "supports output transformation" do
+      get lookbook_preview_path("phlex_example/transform")
+
+      expect(html.has_css?("span", text: "transformed")).to be true
     end
   end
 end


### PR DESCRIPTION
So this is my take on an idea to enable full manipulation of the outputted HTML for a given Preview...

The reason I'm looking for this capability is that I am trying to build a component system for emails using Phlex & Lookbook, and I want the output to more closely match the processing we do on outgoing emails to inline CSS and automatically set some attributes on HTML elements.

With this change, I can subclass all my email components from a base class where I override `render(...)` to add the default `:output_transformation` they'll all use, and when looking at any individual preview you won't see any of that in the Source panel, but the transformation will be reflected in the Preview & HTML panels.

I was first trying to implement this through the `layout`, which technically worked, but the inlined CSS would only be visible on the Preview panel and not the HTML panel.

Do you think this is a good approach to implement this feature, or do you have suggestions of a different way to implement this?