### PR TITLE
@after_render scenario output transform

### DIFF
--- a/app/controllers/concerns/lookbook/targetable_concern.rb
+++ b/app/controllers/concerns/lookbook/targetable_concern.rb
@@ -96,7 +96,7 @@ module Lookbook
 
       scenarios = @target ? @target.scenarios : []
       rendered_scenarios = scenarios.map do |scenario|
-        output = preview_controller.process(:render_scenario_to_string, @preview, scenario.name)
+        output = preview_controller.process(:render_scenario_to_string, @preview, scenario)
         RenderedScenarioEntity.new(scenario, output, preview_controller.params)
       end
 

--- a/config/tags.yml
+++ b/config/tags.yml
@@ -38,3 +38,7 @@ shared:
   source:
     label: Source file
     opts: {}
+
+  after_render:
+    label: After render
+    opts: {}

--- a/lib/lookbook/engine.rb
+++ b/lib/lookbook/engine.rb
@@ -45,6 +45,8 @@ module Lookbook
         if vc_config.view_component_path.present?
           opts.component_paths << vc_config.view_component_path
         end
+
+        ViewComponent::Preview.extend(Lookbook::PreviewAfterRender)
       end
 
       opts.reload_on_change = host_config.reload_classes_only_on_change if opts.reload_on_change.nil?

--- a/lib/lookbook/entities/preview_entity.rb
+++ b/lib/lookbook/entities/preview_entity.rb
@@ -7,7 +7,7 @@ module Lookbook
     include LocatableEntity
     include NavigableEntity
 
-    delegate :render_args, to: :preview_class
+    delegate :after_render, :render_args, to: :preview_class
 
     # @api private
     attr_reader :preview_class
@@ -156,6 +156,11 @@ module Lookbook
     def display_options
       global_options = Lookbook.config.preview_display_options
       global_options.deep_merge(fetch_config(:display_options, {}))
+    end
+
+    # @api private
+    def after_render_method
+      fetch_config(:after_render)
     end
 
     # @api private

--- a/lib/lookbook/entities/scenario_entity.rb
+++ b/lib/lookbook/entities/scenario_entity.rb
@@ -111,6 +111,11 @@ module Lookbook
     # @!endgroup
 
     # @api private
+    def after_render_method
+      fetch_config(:after_render) || parent.after_render_method
+    end
+
+    # @api private
     def scenarios
       [self]
     end

--- a/lib/lookbook/preview.rb
+++ b/lib/lookbook/preview.rb
@@ -2,6 +2,7 @@ module Lookbook
   class Preview
     include ActionView::Helpers::TagHelper
     include ActionView::Helpers::AssetTagHelper
+    extend PreviewAfterRender
 
     def render(component = nil, **args, &block)
       if component.nil?

--- a/lib/lookbook/preview_after_render.rb
+++ b/lib/lookbook/preview_after_render.rb
@@ -1,0 +1,8 @@
+module Lookbook
+  # Shared module that both Lookbook::Preview and ViewComponent::Preview are extended with
+  module PreviewAfterRender
+    def after_render(method:, html:)
+      new.send(method, html).html_safe
+    end
+  end
+end

--- a/lib/lookbook/preview_controller_actions.rb
+++ b/lib/lookbook/preview_controller_actions.rb
@@ -6,12 +6,12 @@ module Lookbook
       helper PreviewHelper
       prepend_view_path Engine.root.join("app/views")
 
-      def render_scenario_to_string(preview, scenario_name)
+      def render_scenario_to_string(preview, scenario)
         prepend_application_view_paths
         prepend_preview_examples_view_path
 
         @preview = preview
-        @scenario_name = scenario_name
+        @scenario_name = scenario.name
         @render_args = @preview.render_args(@scenario_name, params: params.permit!)
         template = @render_args[:template]
         locals = @render_args[:locals]
@@ -19,8 +19,12 @@ module Lookbook
         opts[:layout] = nil
         opts[:locals] = locals if locals.present?
 
+        rendered = render_to_string(template, **opts)
+
+        rendered = @preview.after_render(method: scenario.after_render_method, html: rendered) if scenario.after_render_method.present?
+
         with_optional_action_view_annotations do
-          render html: render_to_string(template, **opts)
+          render html: rendered
         end
       end
 

--- a/lib/lookbook/tags/after_render_tag.rb
+++ b/lib/lookbook/tags/after_render_tag.rb
@@ -1,0 +1,7 @@
+module Lookbook
+  class AfterRenderTag < YardTag
+    def value
+      text.sub(/\A:/, "")
+    end
+  end
+end

--- a/spec/dummy/test/components/previews/after_render_component_preview.rb
+++ b/spec/dummy/test/components/previews/after_render_component_preview.rb
@@ -1,0 +1,25 @@
+# @after_render :preview_after_render
+class AfterRenderComponentPreview < Lookbook::Preview
+  def default
+    render StandardComponent.new do
+      "default after render content"
+    end
+  end
+
+  # @after_render :scenario_after_render
+  def custom
+    render StandardComponent.new do
+      "custom after render content"
+    end
+  end
+
+  private
+
+  def preview_after_render(html)
+    "<em>preview</em>#{html}"
+  end
+
+  def scenario_after_render(html)
+    "<strong>scenario</strong>#{html}"
+  end
+end

--- a/spec/dummy/test/components/previews/after_render_view_component_example_preview.rb
+++ b/spec/dummy/test/components/previews/after_render_view_component_example_preview.rb
@@ -1,0 +1,25 @@
+# @after_render :preview_after_render
+class AfterRenderViewComponentExamplePreview < ViewComponent::Preview
+  def default
+    render StandardComponent.new do
+      "default after render content"
+    end
+  end
+
+  # @after_render :scenario_after_render
+  def custom
+    render StandardComponent.new do
+      "custom after render content"
+    end
+  end
+
+  private
+
+  def preview_after_render(html)
+    "<em>preview</em>#{html}"
+  end
+
+  def scenario_after_render(html)
+    "<strong>scenario</strong>#{html}"
+  end
+end

--- a/spec/lib/tags/after_render_tag_spec.rb
+++ b/spec/lib/tags/after_render_tag_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Lookbook::AfterRenderTag do
+  it "extends Lookbook::YardTag" do
+    expect(described_class).to be < Lookbook::YardTag
+  end
+
+  context ".value" do
+    it "returns text as-is if it doesn't start with a ':'" do
+      tag = described_class.new("my_method")
+      expect(tag.value).to eq "my_method"
+    end
+
+    it "strips leading ':'" do
+      tag = described_class.new(":my_method")
+      expect(tag.value).to eq "my_method"
+    end
+  end
+end

--- a/spec/requests/previews_spec.rb
+++ b/spec/requests/previews_spec.rb
@@ -38,4 +38,36 @@ RSpec.describe "previews", type: :request do
       expect(html).to have_content "http://localhost/"
     end
   end
+
+  context "after_render" do
+    it "supports preview class after_render" do
+      get lookbook_preview_path("after_render/default")
+
+      expect(html.has_css?("em", text: "preview")).to be true
+      expect(html).to have_content "default after render content"
+    end
+
+    it "supports scenario after_render" do
+      get lookbook_preview_path("after_render/custom")
+
+      expect(html.has_css?("strong", text: "scenario")).to be true
+      expect(html).to have_content "custom after render content"
+    end
+
+    context "in ViewComponent::Preview" do
+      it "supports preview class after_render" do
+        get lookbook_preview_path("after_render_view_component_example/default")
+
+        expect(html.has_css?("em", text: "preview")).to be true
+        expect(html).to have_content "default after render content"
+      end
+
+      it "supports scenario after_render" do
+        get lookbook_preview_path("after_render_view_component_example/custom")
+
+        expect(html.has_css?("strong", text: "scenario")).to be true
+        expect(html).to have_content "custom after render content"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Based on the discussion in #371, here's another take on providing a way for folks to transform the HTML output of a scenario after running the render.

This time through a new tag: `@after_render`. It can be put on the preview class or the scenario method, with the method taking higher priority. You provide the name of a private method to call that will receive one argument, a string of the rendered HTML.

Example:
```ruby
class MyComponentPreview < Lookbook::Preview
  # @after_render :prepend_test
  def default
    render MyComponent.new
  end

  private

  def prepend_test(html)
    "<p>test</p>#{html}"
  end
end