### PR TITLE
Add support for collapsing preview paths via Zeitwerk

### DIFF
--- a/lib/lookbook/entities/collections/preview_collection.rb
+++ b/lib/lookbook/entities/collections/preview_collection.rb
@@ -44,7 +44,10 @@ module Lookbook
     class << self
       def preview_from_code_object(code_object)
         klass = code_object.path.constantize
-        PreviewEntity.new(code_object) if preview_class?(klass)
+        if preview_class?(klass)
+          preview = PreviewEntity.new(code_object)
+          preview if preview.scenarios.any?
+        end
       rescue => exception
         Lookbook.logger.error exception.to_s
         nil

--- a/lib/lookbook/entities/concerns/locatable_entity.rb
+++ b/lib/lookbook/entities/concerns/locatable_entity.rb
@@ -75,7 +75,10 @@ module Lookbook
       def logical_path
         return @_logical_path if @_logical_path
 
-        directory = fetch_config(:logical_path) { relative_directory_path.to_s }
+        directory = fetch_config(:logical_path) do
+          parts = lookup_path.split("/")
+          parts.many? ? parts[..-2].join("/") : nil
+        end
         @_logical_path ||= PathUtils.to_path(directory, file_name_base)
       end
 

--- a/lib/lookbook/entities/preview_entity.rb
+++ b/lib/lookbook/entities/preview_entity.rb
@@ -19,9 +19,9 @@ module Lookbook
       @file_path = Pathname(code_object.file)
       @base_directories = Engine.preview_paths
 
-      cleaned_path = relative_file_path.to_s
-        .gsub(/\/(component_preview|preview)(\..*)$/, "")
-        .gsub(/(_component_preview|_preview)(\..*)$/, "")
+      cleaned_path = preview_class.name.underscore.strip
+        .gsub(/(_component_preview|_preview)(\..+)?$/, "")
+        .gsub(/\/(component_preview|preview|component)(\..+)?$/, "")
 
       @lookup_path = PathUtils.to_lookup_path(cleaned_path)
     end
@@ -149,7 +149,7 @@ module Lookbook
 
     # @api private
     def file_name_base
-      @_file_name_slug ||= file_name(true).gsub(/(_component_preview|component_preview|preview)$/, "")
+      @_file_name_slug ||= file_name(true).gsub(/(_component_preview|component_preview|_preview|preview|component)$/, "")
     end
 
     # @api private

--- a/lib/lookbook/entities/scenario_entity.rb
+++ b/lib/lookbook/entities/scenario_entity.rb
@@ -172,7 +172,7 @@ module Lookbook
 
       render_targets = render_target_identifiers.map do |render_target|
         RenderableEntity.new(render_target)
-      rescue NameError
+      rescue Lookbook::Error, NameError
         Lookbook.logger.warn "#{render_target} was not found"
         nil
       end


### PR DESCRIPTION
Makes a few changes to the way that paths are constructed to ensure that previews within [collapsed directories](https://github.com/fxn/zeitwerk/blob/main/README.md#collapsing-directories) display correctly in the navigation.

More details/discussion in the original feature request from @ksweetie here: https://github.com/ViewComponent/lookbook/issues/375