### PR TITLE
Fix typos and link in v2 user guide

### DIFF
--- a/docs/src/_data/tags.yml
+++ b/docs/src/_data/tags.yml
@@ -4,7 +4,7 @@
     - name: <text>
       types: String
       text: Text to use for the label
-  description: "Customises the label to displayed in the nav."
+  description: "Customises the label to display in the nav."
   example: |
     # @label Primary Button
     def main_but

--- a/docs/src/_guide/concepts.md
+++ b/docs/src/_guide/concepts.md
@@ -41,7 +41,7 @@ title: Key Concepts & Terminology
   
   Annotations are comments added to preview classes that can be used to customise the preview experience and to provide extra information to end-users.
 
-  [Read more about annotations &rarr;](<%= guide_url :annotations %>)
+  [Read more about annotations &rarr;](<%= guide_url :previews_annotations %>)
 
 <% end %>
 

--- a/docs/src/_guide/whats_new.md
+++ b/docs/src/_guide/whats_new.md
@@ -1,7 +1,7 @@
 ---
 id: whats-new
-label: Whats New
-title: Whats New in v2.0
+label: What's New
+title: What's New in v2.0
 goals: 
   - icon: layers
     text: "Support for previewing a **range of component types**"
@@ -87,7 +87,7 @@ goals:
 <%= render section("Better file watching", id: "live-reload") do |s| %>
   <% s.with_block_prose do %>
     Lookbook's file watching system has been completely overhauled and is now much more closely integrated
-    with Rail's own change detection/code reloading system.
+    with Rails' own change detection/code reloading system.
 
     This means that some long-standing issues (such as detecting changes on forked servers with multiple processes running) have been resolved
     and the `listen` and `actioncable` gems are now only optional dependencies that can be omitted from production (or entirely!).


### PR DESCRIPTION
### What does this PR do?
It fixes some minor issues in the v2 docs:

- Fix the link to "Using Annotations" on the Get Started > Key Concepts page
- Fix 1 typo on the Other > Tags Reference page
- Fix some typos on the Get Started > What's New page