### PR TITLE
Fix URL helpers in previews

### DIFF
--- a/app/controllers/concerns/lookbook/with_preview_controller_concern.rb
+++ b/app/controllers/concerns/lookbook/with_preview_controller_concern.rb
@@ -3,12 +3,23 @@ module Lookbook
     extend ActiveSupport::Concern
 
     def preview_controller
-      return @_preview_controller if @_preview_controller
+      @_preview_controller ||= begin
+        # In order to get URL helpers working correctly in the preview,
+        # the request needs to look like it's coming from the host app,
+        # not the Lookbook engine. So we try to get the controller and action
+        # for the root path and use that as the 'fake' request context instead.
+        request_path = main_app.respond_to?(:root_path) ? main_app.root_path : "/"
+        path_parameters = Rails.application.routes.recognize_path(request_path)
 
-      controller = Engine.preview_controller.new
-      controller.request = request
-      controller.response = response
-      @_preview_controller ||= controller
+        preview_request = request.clone
+        preview_request.path_parameters = path_parameters if path_parameters.present?
+
+        controller = Engine.preview_controller.new
+        controller.request = preview_request
+        controller.response = response
+
+        controller
+      end
     end
   end
 end

--- a/lib/lookbook/helpers/preview_helper.rb
+++ b/lib/lookbook/helpers/preview_helper.rb
@@ -10,9 +10,5 @@ module Lookbook
     def lookbook_data(key, fallback = nil)
       Lookbook.data.fetch(key.to_sym, fallback)
     end
-
-    def url_for(*args)
-      main_app.url_for(*args)
-    end
   end
 end

--- a/lib/lookbook/preview_controller_actions.rb
+++ b/lib/lookbook/preview_controller_actions.rb
@@ -5,56 +5,56 @@ module Lookbook
     included do
       helper PreviewHelper
       prepend_view_path Engine.root.join("app/views")
+    end
 
-      def render_scenario_to_string(preview, scenario)
-        prepend_application_view_paths
-        prepend_preview_examples_view_path
+    def render_scenario_to_string(preview, scenario)
+      prepend_application_view_paths
+      prepend_preview_examples_view_path
 
-        @preview = preview
-        @scenario_name = scenario.name
-        @render_args = @preview.render_args(@scenario_name, params: params.permit!)
-        template = @render_args[:template]
-        locals = @render_args[:locals]
-        opts = {}
-        opts[:layout] = nil
-        opts[:locals] = locals if locals.present?
+      @preview = preview
+      @scenario_name = scenario.name
+      @render_args = @preview.render_args(@scenario_name, params: params.permit!)
+      template = @render_args[:template]
+      locals = @render_args[:locals]
+      opts = {}
+      opts[:layout] = nil
+      opts[:locals] = locals if locals.present?
 
-        rendered = render_to_string(template, **opts)
+      rendered = render_to_string(template, **opts)
 
-        if scenario.after_render_method.present?
-          render_context = Store.new({
-            preview: preview,
-            scenario: scenario,
-            params: user_request_parameters
-          })
-          rendered = @preview.after_render(method: scenario.after_render_method, html: rendered, context: render_context)
+      if scenario.after_render_method.present?
+        render_context = Store.new({
+          preview: preview,
+          scenario: scenario,
+          params: user_request_parameters
+        })
+        rendered = @preview.after_render(method: scenario.after_render_method, html: rendered, context: render_context)
+      end
+
+      with_optional_action_view_annotations do
+        render html: rendered
+      end
+    end
+
+    def render_in_layout_to_string(template, locals, opts = {})
+      with_optional_action_view_annotations do
+        html = render_to_string(template, locals: locals, **determine_layout(opts[:layout]))
+        if opts[:append_html].present?
+          html += opts[:append_html]
         end
-
-        with_optional_action_view_annotations do
-          render html: rendered
-        end
+        render html: html
       end
+    end
 
-      def render_in_layout_to_string(template, locals, opts = {})
-        with_optional_action_view_annotations do
-          html = render_to_string(template, locals: locals, **determine_layout(opts[:layout]))
-          if opts[:append_html].present?
-            html += opts[:append_html]
-          end
-          render html: html
-        end
-      end
+    protected
 
-      protected
+    def with_optional_action_view_annotations(&block)
+      disable = Lookbook.config.preview_disable_action_view_annotations
+      ActionViewAnnotationsHandler.call(disable_annotations: disable, &block)
+    end
 
-      def with_optional_action_view_annotations(&block)
-        disable = Lookbook.config.preview_disable_action_view_annotations
-        ActionViewAnnotationsHandler.call(disable_annotations: disable, &block)
-      end
-
-      def user_request_parameters
-        request.query_parameters.to_h.filter { |k, v| !k.start_with?("_") }
-      end
+    def user_request_parameters
+      request.query_parameters.to_h.filter { |k, v| !k.start_with?("_") }
     end
   end
 end

--- a/lib/lookbook/preview_controller_actions.rb
+++ b/lib/lookbook/preview_controller_actions.rb
@@ -4,6 +4,7 @@ module Lookbook
 
     included do
       helper PreviewHelper
+      helper Rails.application.routes.url_helpers
       prepend_view_path Engine.root.join("app/views")
     end
 

--- a/spec/dummy/app/controllers/blog_controller.rb
+++ b/spec/dummy/app/controllers/blog_controller.rb
@@ -1,0 +1,4 @@
+class BlogController < ApplicationController
+  def index
+  end
+end

--- a/spec/dummy/app/views/partials/_helpers_example.html.erb
+++ b/spec/dummy/app/views/partials/_helpers_example.html.erb
@@ -1,1 +1,1 @@
-<%= url_for(:root) %>
+<a href="<%= url_for(:root) %>"></a>

--- a/spec/dummy/app/views/partials/_url_helpers_example.html.erb
+++ b/spec/dummy/app/views/partials/_url_helpers_example.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Blog", blog_path %>

--- a/spec/dummy/app/views/phlex/helpers_example.rb
+++ b/spec/dummy/app/views/phlex/helpers_example.rb
@@ -1,7 +1,7 @@
 module Views::Phlex
   class HelpersExample < Phlex::HTML
     def template
-      p { helpers.url_for(:root) }
+      a(href: helpers.url_for(:root)) { "click here" }
     end
   end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,5 +2,8 @@
 
 Rails.application.routes.draw do
   root "home#index"
+
+  get "/blog", to: "blog#index"
+
   mount Lookbook::Engine, at: "/lookbook"
 end

--- a/spec/dummy/test/components/previews/partial_example_preview.rb
+++ b/spec/dummy/test/components/previews/partial_example_preview.rb
@@ -6,4 +6,8 @@ class PartialExamplePreview < Lookbook::Preview
   def helpers
     render "partials/helpers_example"
   end
+
+  def url_helpers
+    render "partials/url_helpers_example"
+  end
 end

--- a/spec/requests/previews_spec.rb
+++ b/spec/requests/previews_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "previews", type: :request do
       it "supports helpers" do
         get lookbook_preview_path("phlex_example/helpers")
 
-        expect(html).to have_content "http://localhost/"
+        expect(html).to have_selector "a[href='/']"
       end
     end
   end
@@ -43,7 +43,7 @@ RSpec.describe "previews", type: :request do
     it "supports helpers" do
       get lookbook_preview_path("partial_example/helpers")
 
-      expect(html).to have_content "http://localhost/"
+      expect(html).to have_selector "a[href='/']"
     end
   end
 

--- a/spec/requests/previews_spec.rb
+++ b/spec/requests/previews_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe "previews", type: :request do
 
       expect(html).to have_selector "a[href='/']"
     end
+
+    it "has access to host app url helpers" do
+      get lookbook_preview_path("partial_example/url_helpers")
+      puts html.native.inner_html
+      expect(html).to have_selector "a[href='/blog']"
+    end
   end
 
   context "after_render" do


### PR DESCRIPTION
Tweaks path parameters for previews to make it appear that the preview is being rendered by the host app, not the Lookbook engine.

