### PR TITLE
DO NOT MERGE - Use experimental CSP-friendly Alpine package

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,4 +1,4 @@
-import Alpine from "alpinejs";
+import Alpine from "@alpinejs/csp";
 
 import Morph from "@alpinejs/morph";
 import Persist from "@alpinejs/persist";

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "lookbook",
       "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@alpinejs/collapse": "^3.10.5",
+        "@alpinejs/csp": "https://gitpkg.now.sh/alpinejs/alpine/packages/csp?main",
         "@alpinejs/morph": "^3.10.5",
         "@alpinejs/persist": "^3.10.5",
         "@rails/actioncable": "^6.1.4",
@@ -53,6 +53,15 @@
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.12.0.tgz",
       "integrity": "sha512-/LKUr6lZD9yYSkTcwm/8eaTd/S2S4NPY9mQJHBy3TTTNai9rLzV15oHcLW0MxausaCOT5jQtQHWFTWelldZOSw=="
+    },
+    "node_modules/@alpinejs/csp": {
+      "version": "3.0.0-alpha.0",
+      "resolved": "https://gitpkg.now.sh/alpinejs/alpine/packages/csp?main",
+      "integrity": "sha512-ilpPGBJb04Y6alxGvEJUOuirYd1n85tUoEAT8hppQe4YnCUtvEP0daBRFVlWqbXazg5DcwZ/CorX4yJav5vaAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "^3.0.2"
+      }
     },
     "node_modules/@alpinejs/morph": {
       "version": "3.12.0",
@@ -10243,6 +10252,13 @@
       "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.12.0.tgz",
       "integrity": "sha512-/LKUr6lZD9yYSkTcwm/8eaTd/S2S4NPY9mQJHBy3TTTNai9rLzV15oHcLW0MxausaCOT5jQtQHWFTWelldZOSw=="
     },
+    "@alpinejs/csp": {
+      "version": "https://gitpkg.now.sh/alpinejs/alpine/packages/csp?main",
+      "integrity": "sha512-ilpPGBJb04Y6alxGvEJUOuirYd1n85tUoEAT8hppQe4YnCUtvEP0daBRFVlWqbXazg5DcwZ/CorX4yJav5vaAA==",
+      "requires": {
+        "@vue/reactivity": "^3.0.2"
+      }
+    },
     "@alpinejs/morph": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.12.0.tgz",
@@ -16646,7 +16662,6 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "license": "MIT",
   "dependencies": {
     "@alpinejs/collapse": "^3.10.5",
+    "@alpinejs/csp": "https://gitpkg.now.sh/alpinejs/alpine/packages/csp?main",
     "@alpinejs/morph": "^3.10.5",
     "@alpinejs/persist": "^3.10.5",
     "@rails/actioncable": "^6.1.4",


### PR DESCRIPTION
We’re heavy users of Lookbook at GitHub. In addition to our public Primer ViewComponents Lookbook (https://primer.style/view-components/lookbook/inspect/primer/beta/blankslate/default/), we use Lookbook internally for our application-specific components. Recently, we’ve been looking into deploying our internal Lookbook to production.

One blocker to doing so is resolving the compromised CSP configuration we've had to use to run Lookbook, which requires unsafe-eval due to usage of AlpineJS. In looking into this issue, I found that Alpine has an experimental CSP-friendly package. I've added it in this PR for the sake of testing by others to see if anything is broken.

How does this look to you @allmarkedup?