### PR TITLE
Live reload can't be used when console gem is present

### DIFF
--- a/lib/lookbook/runtime_context.rb
+++ b/lib/lookbook/runtime_context.rb
@@ -35,7 +35,7 @@ module Lookbook
     end
 
     def web?
-      !rake_task? && !Rails.const_defined?(:Console)
+      !rake_task? && !Rails.const_defined?(:Console, false)
     end
 
     def rake_task?


### PR DESCRIPTION
I found this problem not because I'm directly using the `console` gem, I actually didn't even realize I had it. But `console` is a dependency of `async` which is likely to be a much more common gem to be used in a Rails app.

The `console` gem defines the constant `Console`.

In the `Lookbook::RuntimeContext`, in order to determine if we're in the Rails console or not, there is a check for `Rails.const_defined?(:Console)`.

This will always return true if the `async` gem is loaded, because even though `Rails::Console` is not found `::Console` is found.

The fix here is to not look in inherited scopes, by passing false as the second argument to `const_defined?`.