### PR TITLE
Bug Fix: Error message title not wrapping causes text overflow

### DIFF
--- a/public/lookbook-assets/css/lookbook.css
+++ b/public/lookbook-assets/css/lookbook.css
@@ -1526,7 +1526,6 @@ pre[class*="language-"] {
 
 [data-component="message"] .message-title {
   text-overflow: ellipsis;
-  white-space: nowrap;
   text-transform: uppercase;
   letter-spacing: .025em;
   color: var(--lookbook-message-title);


### PR DESCRIPTION
Ran into an error page and noticed the error message ran off the side of the page. This change removes `white-space: nowrap;` from `[data-component="message"] .message-title` to allow for reading the entire error.

**BEFORE**
<img width="1533" alt="Screenshot 2023-04-19 at 1 25 11 PM" src="https://user-images.githubusercontent.com/2224702/233153054-78599812-fa94-4387-9996-c14486739cad.png">

**AFTER**
<img width="1535" alt="Screenshot 2023-04-19 at 1 25 27 PM" src="https://user-images.githubusercontent.com/2224702/233153052-25fb226b-21e7-4ac3-bb3a-06648ed76d8f.png">