### PR TITLE
Fix multi-line parameter defaults

### DIFF
--- a/app/components/lookbook/params/field/component.rb
+++ b/app/components/lookbook/params/field/component.rb
@@ -14,7 +14,7 @@ module Lookbook
         styles, html = StylesExtractor.call(render_input)
         Editor::Component.add_styles(param.input, styles)
 
-        escaped_value = json_escape(param.value.to_s)
+        escaped_value = json_escape(param.value.to_s).gsub("\n", '\n')
         wrapper_attrs = {
           data: {"param-input": param.input},
           "x-data": "paramsInputComponent({name: \"#{param.name}\", value: \"#{escaped_value}\"})"

--- a/docs/src/_extend/contributing.md
+++ b/docs/src/_extend/contributing.md
@@ -50,13 +50,14 @@ title: Contributing to Lookbook
   * **Include a concise description** of what the PR contains.
   * **Follow Lookbook's coding conventions** &mdash; we use [Standard](https://github.com/testdouble/standard) for Ruby linting/formatting and [Prettier](https://prettier.io/) for almost everything else.
   * **Follow Lookbook's commit message conventions** &mdash; we use [Angular-style](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) commit messages.
-  * **Ensure that the existing tests pass**, and preferrably add more tests around the bug or feature addressed in  the PR.
+  * **Ensure that the existing tests pass**, and preferably add more tests around the bug or feature addressed in  the PR.
 
   Steps:
 
   * Fork and clone the repository.
   * Configure and install the dependencies: `bundle install`.
-  * Make sure the tests pass: `rake test`.
+  * Set up appraisal: `bundle exec appraisal install`.
+  * Make sure the tests pass: `rake spec`.
   * Create a new branch: `git checkout -b my-branch-name`.
   * Add tests, make the change, and make sure the tests still pass.
   * Push to the fork and submit a pull request.

--- a/spec/dummy/test/components/previews/params_component_preview.rb
+++ b/spec/dummy/test/components/previews/params_component_preview.rb
@@ -1,5 +1,9 @@
 class ParamsComponentPreview < ViewComponent::Preview
-  TEXT = "the default value"
+  TEXT = <<~TEXT
+    the multiline
+
+    default value
+  TEXT
 
   # @param select select
   # @param textarea textarea
@@ -34,7 +38,7 @@ class ParamsComponentPreview < ViewComponent::Preview
     end
   end
 
-  # @param body_text
+  # @param body_text textarea
   def dynamic_args(body_text: TEXT)
     render StandardComponent.new do
       body_text

--- a/spec/requests/previews_spec.rb
+++ b/spec/requests/previews_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe "previews", type: :request do
     it "renders previews with non-static default param values" do
       get lookbook_preview_path("params/dynamic_args")
 
-      expect(html).to have_content "the default value"
+      expect(html).to have_content "the multiline"
+      expect(html).to have_content "default value"
     end
   end
 

--- a/spec/system/params_editor_spec.rb
+++ b/spec/system/params_editor_spec.rb
@@ -34,4 +34,18 @@ RSpec.describe "Params editor", type: :system do
       end
     end
   end
+
+  context "textarea" do
+    before do
+      visit lookbook_inspect_path("params/dynamic_args")
+    end
+
+    it "properly interprets values with newlines" do
+      within("#app-main") do
+        click_on "Params"
+      end
+
+      expect(page.find("textarea").value).to eql ParamsComponentPreview::TEXT
+    end
+  end
 end


### PR DESCRIPTION
I noticed a bug with the new dynamic parameter handling feature where default values containing newlines were breaking the JS. This PR addresses that very simply by escaping newlines. I don't know enough about AlpineJS to know if there's a more elegant way to accomplish this escaping. Happy to adjust if there's something cleaner.