### PR TITLE
fix: update copy button icon slot to use ViewComponent SlotsV2

### DIFF
--- a/app/components/lookbook/copy_button/component.html.erb
+++ b/app/components/lookbook/copy_button/component.html.erb
@@ -3,8 +3,8 @@
   **@button_attrs,
   "x-data": prepare_alpine_data,
   "@click.prevent": "copyToClipboard" do |button| %>
-  <% button.icon name: @icon, size: icon_size, "x-show": "!copied", cloak: true %>
-  <%= icon  :check, size: icon_size, class: "text-green-500", "x-show": "copied", cloak: true  %>
+  <% button.with_icon name: @icon, size: icon_size, "x-show": "!copied", cloak: true %>
+  <%= icon :check, size: icon_size, class: "text-green-500", "x-show": "copied", cloak: true %>
   <% if content %>
     <div x-ref="copyTarget" class="hidden"><%== content %></div>
   <% end %>


### PR DESCRIPTION
The copy button component is incompatible with ViewComponent v3.0 since it uses the removed slot setter in its template. This PR updates this component to use the `with_SLOT_NAME` setter. 