### PR TITLE
fix: Add explicit dependency on marcel

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ PATH
       css_parser
       htmlbeautifier (~> 1.3)
       htmlentities (~> 4.3.4)
+      marcel (~> 1.0)
       railties (>= 5.0)
       redcarpet (~> 3.5)
       rouge (>= 3.26, < 5.0)

--- a/lookbook.gemspec
+++ b/lookbook.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "yard", "~> 0.9.25"
   spec.add_dependency "htmlbeautifier", "~> 1.3"
   spec.add_dependency "htmlentities", "~> 4.3.4"
+  spec.add_dependency "marcel", "~> 1.0"
 end


### PR DESCRIPTION
There is an explicit require of `marcel` [here](https://github.com/ViewComponent/lookbook/blob/280c1304ac0028918bed8fba2337c383eaabe3b7/lib/lookbook/services/urls/file_data_uri_encoder.rb#L1), but it is not declared as a dependency of the gem. Otherwise, `marcel` is usually loaded with activestorage.