### PR TITLE
Fix two small bugs in param tag options parsing.

### DIFF
--- a/lib/lookbook/tags/param_tag.rb
+++ b/lib/lookbook/tags/param_tag.rb
@@ -1,7 +1,7 @@
 module Lookbook
   class ParamTag < YardTag
     VALUE_TYPE_MATCHER = /^(\[\s?([A-Z]{1}\w+)\s?\])/
-    DESCRIPTION_MATCHER = /(?<=\s|^)"(.*[^\\])"(?:\s|$)/
+    DESCRIPTION_MATCHER = /(?<=\s|^)"(.*?[^\\])"(?:\s|$)/
 
     supports_options
 
@@ -52,7 +52,7 @@ module Lookbook
 
       text.match(DESCRIPTION_MATCHER) do |match_data|
         description = match_data[1]
-        text.gsub!(DESCRIPTION_MATCHER, "").strip!
+        text.sub!(DESCRIPTION_MATCHER, "").strip!
       end
 
       input, rest = text.split(" ", 2)

--- a/spec/lib/tags/param_tag_spec.rb
+++ b/spec/lib/tags/param_tag_spec.rb
@@ -63,5 +63,18 @@ RSpec.describe Lookbook::ParamTag do
         expect(tag.description).to eq "a description"
       end
     end
+
+    context "with options" do
+      let(:tag) { described_class.new('foo select "a description" { choices: [primary, secondary, danger], value_type: "Symbol" }') }
+
+      it "parses the description" do
+        expect(tag.description).to eq "a description"
+      end
+
+      it "parses the options" do
+        expect(tag.options[:value_type]).to eql "Symbol"
+        expect(tag.options[:choices]).to eql ["primary", "secondary", "danger"]
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a two small bugs that I noticed in how descriptions are handled in `@param` tags, particularly when there are tag options containing double-quoted strings.

1. The `DESCRIPTION_MATCHER` regex in `ParamTag` was greedy-matching the paired `"` character. It should be non-greedy. I was getting a description of `Whether this should be on or not" { value_type: "Boolean` on my parameter in the UI.
2. The `DESCRIPTION_MATCHER` was getting passed to `gsub!` rather than `sub!` when it matched, so the tag option string getting passed to `YardTag` looked like `{ choices: [primary, secondary], value_type: }` instead of `{ choices: [primary, secondary], value_type: "Symbol" }` because the `"Symbol"` was being removed by `gsub`.

I added a couple of tests for options in the `ParamTag` spec. They will both fail if the implementation changes in here are removed. I wouldn't be surprised at all if there were some other odd bugs that could be turned up with some more thorough tests though!