### PR TITLE
Fix noisy data resolver on startup

### DIFF
--- a/lib/lookbook/services/tags/tag_options_parser.rb
+++ b/lib/lookbook/services/tags/tag_options_parser.rb
@@ -9,18 +9,27 @@ module Lookbook
 
     def initialize(input, resolver_opts = {})
       @input = input.to_s.strip
-      @resolver_opts = resolver_opts
+      @resolve = resolver_opts.fetch(:resolve, true)
+      @resolver_opts = resolver_opts.except(:resolve)
       @fallback = resolver_opts.fetch(:fallback, {})
     end
 
     def call
       options_string, remaining_text = parse_input(@input)
-      resolved_options = resolver(options_string).call(options_string, **@resolver_opts)
-      options = prepare_options(resolved_options)
-      [options, remaining_text]
+      if resolve?
+        resolved_options = resolver(options_string).call(options_string, **@resolver_opts)
+        options = prepare_options(resolved_options)
+        [options, remaining_text]
+      else
+        [options_string, remaining_text]
+      end
     end
 
     protected
+
+    def resolve?
+      !!@resolve
+    end
 
     def resolver(options_string)
       if options_string.present?

--- a/lib/lookbook/tags/param_tag.rb
+++ b/lib/lookbook/tags/param_tag.rb
@@ -52,9 +52,7 @@ module Lookbook
       end
 
       # Parse and remove any options from string
-      text_with_options = text
-      _, text = parse_options(text)
-      options_str = text_with_options.sub(text, "")
+      options_str, text = parse_options(text, resolve: false)
 
       # Parse description, if provided
       text.match(DESCRIPTION_MATCHER) do |match_data|
@@ -64,7 +62,12 @@ module Lookbook
 
       input, rest = text.split(" ", 2)
 
-      {input: input, value_type: value_type, description: description, rest: [rest, options_str].compact.join(" ")}
+      {
+        input: input,
+        value_type: value_type,
+        description: description,
+        rest: [rest, options_str].compact.join(" ")
+      }
     end
   end
 end

--- a/lib/lookbook/tags/yard_tag.rb
+++ b/lib/lookbook/tags/yard_tag.rb
@@ -78,12 +78,13 @@ module Lookbook
       host_code_object&.path&.constantize
     end
 
-    def parse_options(input)
+    def parse_options(input, resolve: true)
       if self.class.supports_options?
         TagOptionsParser.call(input, {
           file: host_file,
           base_dir: host_file&.dirname,
-          eval_context: host_class_instance
+          eval_context: host_class_instance,
+          resolve: resolve
         })
       else
         [{}, @text]


### PR DESCRIPTION
Stops the `@param` tag data resolver running when initialising the tag classes, which was causing some addition unnecessary overhead and a bunch of debug noise when starting Lookbook. See #458 for background.