### PR TITLE
Silence the `FileWatcher` from always logging the type of watcher

### DIFF
--- a/lib/lookbook/file_watcher.rb
+++ b/lib/lookbook/file_watcher.rb
@@ -2,12 +2,6 @@ module Lookbook
   class FileWatcher
     class << self
       def new(...)
-        if evented?
-          Lookbook.logger.debug "Using `EventedFileUpdateChecker` for file watching"
-        else
-          Lookbook.logger.debug "The 'listen' gem was not found. Using `FileUpdateChecker` for file watching"
-        end
-
         file_watcher.new(...)
       end
 


### PR DESCRIPTION
@allmarkedup I hope you're OK with this proposed change! On application startup, you see one of these messages twice, and it seemed a little chatty.

If someone wants to know which watcher that is used, they can look at `Lookbook.debug_data[:dependencies][:lookbook]` or `Lookbook::Engine.auto_refresh?`.