### PR TITLE
Prefer Enumerable#grep to filter by type

### DIFF
--- a/lib/lookbook/entities/collections/preview_collection.rb
+++ b/lib/lookbook/entities/collections/preview_collection.rb
@@ -44,10 +44,7 @@ module Lookbook
     end
 
     def entities
-      @_cache[:entities] ||= begin
-        all = collect_ordered_entities(to_tree(include_hidden: true))
-        all.filter { _1.is_a?(Lookbook::PreviewEntity) }
-      end
+      @_cache[:entities] ||= collect_ordered_entities(to_tree(include_hidden: true)).grep(Lookbook::PreviewEntity)
     end
 
     class << self


### PR DESCRIPTION
This reformulates a tiny part of the code to use an existing Ruby method.