### PR TITLE
Disable code reloading in production by default

### DIFF
--- a/docs/src/_data/config_options.yml
+++ b/docs/src/_data/config_options.yml
@@ -223,10 +223,10 @@ debugging:
 system:
   - name: reload_on_change
     types: Boolean
-    default: "config.reload_classes_only_on_change"
+    default: "!config.cache_classes && config.reload_classes_only_on_change"
     example: config.lookbook.reload_on_change = true
     description: |
-      By default Lookbook uses the value of the `reload_classes_only_on_change` Rails config option to decide if
+      By default Lookbook uses the value of the `cache_classes` and `reload_classes_only_on_change` Rails config options to decide if
       it should attempt to update the preview data after changes. If set the value of this config option will take precedence and be used instead.
 
   - name: live_updates

--- a/lib/lookbook/engine.rb
+++ b/lib/lookbook/engine.rb
@@ -62,7 +62,9 @@ module Lookbook
         ViewComponent::Preview.extend(Lookbook::PreviewAfterRender)
       end
 
-      opts.reload_on_change = host_config.reload_classes_only_on_change if opts.reload_on_change.nil?
+      if opts.reload_on_change.nil?
+        opts.reload_on_change = !host_config.cache_classes && host_config.reload_classes_only_on_change
+      end
     end
 
     config.after_initialize do


### PR DESCRIPTION
By default a Rails app configs have `cache_classes` as false in develoment and true in production, and does not change `reload_classes_only_on_change` from its default `true`.

This means that Lookbook currently actually watches for changes in Production as well as Development, because it's not taking `cache_classes` into account.

To quote the [Rails Guides](https://guides.rubyonrails.org/threading_and_code_execution.html#configuration):
> The Reloader only checks for file changes when `cache_classes` is false and `reload_classes_only_on_change` is true (which is the default in the `development` environment).
>
> When `cache_classes` is true (in `production`, by default), the Reloader is only a pass-through to the Executor.

I discovered this when my app wouldn't boot in production and instead had this error:
```
[1] ! Unable to load application: Errno::EMFILE: Too many open files - Failed to initialize inotify: the user limit on the total number of inotify instances has been reached.
bundler: failed to load command: puma (/app/vendor/bundle/ruby/3.2.0/bin/puma)
/app/vendor/bundle/ruby/3.2.0/gems/rb-inotify-0.10.1/lib/rb-inotify/notifier.rb:69:in `initialize': Too many open files - Failed to initialize inotify: the user limit on the total number of inotify instances has been reached. (Errno::EMFILE)
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/adapter/linux.rb:29:in `new'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/adapter/linux.rb:29:in `_configure'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/adapter/base.rb:47:in `block in configure'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/adapter/base.rb:42:in `each'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/adapter/base.rb:42:in `configure'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/adapter/base.rb:66:in `start'
    from /usr/lib/fullstaq-ruby/versions/3.2.2-jemalloc/lib/ruby/3.2.0/forwardable.rb:240:in `start'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/listener.rb:71:in `block in <class:Listener>'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/fsm.rb:124:in `instance_eval'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/fsm.rb:124:in `call'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/fsm.rb:105:in `transition_with_callbacks!'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/fsm.rb:72:in `transition'
    from /app/vendor/bundle/ruby/3.2.0/gems/listen-3.8.0/lib/listen/listener.rb:92:in `start'
    from /app/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:115:in `start'
    from /app/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:90:in `initialize'
    from /app/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:42:in `new'
    from /app/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:42:in `initialize'
    from /app/vendor/bundle/ruby/3.2.0/gems/lookbook-2.0.4/lib/lookbook/support/evented_file_update_checker.rb:10:in `initialize'
    from /app/vendor/bundle/ruby/3.2.0/gems/lookbook-2.0.4/lib/lookbook/file_watcher.rb:5:in `new'
    from /app/vendor/bundle/ruby/3.2.0/gems/lookbook-2.0.4/lib/lookbook/file_watcher.rb:5:in `new'
    from /app/vendor/bundle/ruby/3.2.0/gems/lookbook-2.0.4/lib/lookbook/reloaders.rb:64:in `file_watcher'
    from /app/vendor/bundle/ruby/3.2.0/gems/lookbook-2.0.4/lib/lookbook/reloaders.rb:31:in `execute'
    from /app/vendor/bundle/ruby/3.2.0/gems/lookbook-2.0.4/lib/lookbook/reloaders.rb:22:in `block in execute'
    from /app/vendor/bundle/ruby/3.2.0/gems/lookbook-2.0.4/lib/lookbook/reloaders.rb:22:in `each'
    from /app/vendor/bundle/ruby/3.2.0/gems/lookbook-2.0.4/lib/lookbook/reloaders.rb:22:in `execute'
    from /app/vendor/bundle/ruby/3.2.0/gems/lookbook-2.0.4/lib/lookbook/engine.rb:72:in `block in <class:Engine>'
    from /app/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:92:in `block in execute_hook'
```

I've not yet tracked why we have too many files being watched. We don't have that many previews and the error doesn't occur in my local development. I imagine it has to do with bundle installing gems into the `Rails.root.join('vendor/bundle')` directory. Perhaps it's trying to watch every single gem we have installed?

I've worked around this error by setting `config.lookbook.reload_on_change = false` in `config/environments/production.rb`, but this PR aims to create a saner default.

For a little code citation, you'll notice that here when `cache_classes` is true (as it is in production), all of this code no-ops and `reload_classes_only_on_change` isn't even checked.

https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/railties/lib/rails/application/finisher.rb#L184-L212

