### PR TITLE
Disable reload_classes_only_on_change if cache_classes is enabled

### DIFF
--- a/docs/src/_data/config_options.yml
+++ b/docs/src/_data/config_options.yml
@@ -223,7 +223,7 @@ debugging:
 system:
   - name: reload_on_change
     types: Boolean
-    default: "config.reload_classes_only_on_change"
+    default: "!config.cache_classes && config.reload_classes_only_on_change"
     example: config.lookbook.reload_on_change = true
     description: |
       By default Lookbook uses the value of the `reload_classes_only_on_change` Rails config option to decide if

--- a/lib/lookbook/engine.rb
+++ b/lib/lookbook/engine.rb
@@ -62,7 +62,7 @@ module Lookbook
         ViewComponent::Preview.extend(Lookbook::PreviewAfterRender)
       end
 
-      opts.reload_on_change = host_config.reload_classes_only_on_change if opts.reload_on_change.nil?
+      opts.reload_on_change = !host_config.cache_classes && host_config.reload_classes_only_on_change if opts.reload_on_change.nil?
     end
 
     config.after_initialize do


### PR DESCRIPTION
Rails will ignore `config.reload_classes_only_on_change` if `config.cache_classes` is
enabled. https://guides.rubyonrails.org/configuring.html#config-reload-classes-only-on-change: states:

>>>
3.2.30 config.reload_classes_only_on_change

Enables or disables reloading of classes only when tracked files change. By default tracks everything on autoload paths and is set to true. If config.cache_classes is true, this option is ignored.
>>>

It was surprising to us that even though `cache_classes` were set to true that lookbook still instantiated file watchers.