### PR TITLE
Add config option to change the order of section panels in the sidebar

### DIFF
--- a/app/controllers/lookbook/application_controller.rb
+++ b/app/controllers/lookbook/application_controller.rb
@@ -48,7 +48,11 @@ module Lookbook
       @config = Lookbook.config
       @engine = Lookbook.engine
       @embed = !!params[:lookbook_embed]
-      @blank_slate = Engine.pages.none? && Engine.previews.none?
+      @blank_slate = @pages.none? && @previews.none?
+
+      @sidebar_panels = @config.preview_inspector.sidebar_panels.map(&:to_sym).select do |panel|
+        (panel == :pages && @pages.any?) || (panel == :previews && @previews.any?)
+      end
     end
 
     def raise_not_found(message = "Page not found")

--- a/app/views/layouts/lookbook/application.html.erb
+++ b/app/views/layouts/lookbook/application.html.erb
@@ -32,48 +32,52 @@
           "x-on:click.outside": "closeMobileSidebar",
           cloak: true do %>
 
-          <%= lookbook_render :split_layout,
-            alpine_data: "$store.layout.#{@pages.any? && @previews.any? ? "sidebar" : "singleSectionSidebar"}",
-            style: "height: calc(100vh - 2.5rem);" do |layout| %>
+          <% if @sidebar_panels.any? %>  
+            <%= lookbook_render :split_layout,
+              alpine_data: "$store.layout.#{@sidebar_panels.many? ? "sidebar" : "singleSectionSidebar"}",
+              style: "height: calc(100vh - 2.5rem);" do |layout| %>
 
-            <% if @previews.any? %>
-              <% layout.with_pane class: "overflow-hidden" do %>
-                <%= lookbook_render :nav,
-                  id: "previews-nav",
-                  tree: @previews.to_tree,
-                  alpine_data: "$store.nav.previews" do |nav| %>
-                  <%= nav.with_toolbar do |toolbar| %>
-                    <% toolbar.with_section padded: true do %>
-                      <h4 class="pt-1"><%= @config.preview_collection_label %></h4>
-                    <% end %>
-                    <% toolbar.with_section align: :right, padded: false do %>
-                      <%= lookbook_render :button_group, size: :xs do |group| %>
-                        <% group.with_button icon: :minus_square,
-                          tooltip: "Collapse all",
-                          "x-on:click": "closeAll" %>
+              <% @sidebar_panels.each do |panel| %>
+                <% if panel == :previews && @previews.any? %>
+                  <% layout.with_pane class: "overflow-hidden" do %>
+                    <%= lookbook_render :nav,
+                      id: "previews-nav",
+                      tree: @previews.to_tree,
+                      alpine_data: "$store.nav.previews" do |nav| %>
+                      <%= nav.with_toolbar do |toolbar| %>
+                        <% toolbar.with_section padded: true do %>
+                          <h4 class="pt-1"><%= @config.preview_collection_label %></h4>
+                        <% end %>
+                        <% toolbar.with_section align: :right, padded: false do %>
+                          <%= lookbook_render :button_group, size: :xs do |group| %>
+                            <% group.with_button icon: :minus_square,
+                              tooltip: "Collapse all",
+                              "x-on:click": "closeAll" %>
+                          <% end %>
+                        <% end %>
                       <% end %>
+                      <% nav.with_filter store: "$store.nav.previews.filter", placeholder: "Filter previews by name&hellip;" %>
                     <% end %>
                   <% end %>
-                  <% nav.with_filter store: "$store.nav.previews.filter", placeholder: "Filter previews by name&hellip;" %>
                 <% end %>
-              <% end %>
-            <% end %>
 
-            <% if @pages.any? %>
-              <% layout.with_pane class: "overflow-hidden" do %>
-                <%= lookbook_render :nav,
-                  id: "pages-nav",
-                  tree: @pages.to_tree,
-                  alpine_data: "$store.nav.pages" do |nav| %>
-                  <%= nav.with_toolbar do |toolbar| %>
-                    <% toolbar.with_section padded: true do %>
-                      <h4 class="pt-1"><%= @config.page_collection_label %></h4>
-                    <% end %>
-                    <% toolbar.with_section align: :right, padded: false do %>
-                      <%= lookbook_render :button_group, size: :xs do |group| %>
-                        <% group.with_button icon: :minus_square,
-                          tooltip: "Collapse all",
-                          "x-on:click": "closeAll" %>
+                <% if panel == :pages && @pages.any? %>
+                  <% layout.with_pane class: "overflow-hidden" do %>
+                    <%= lookbook_render :nav,
+                      id: "pages-nav",
+                      tree: @pages.to_tree,
+                      alpine_data: "$store.nav.pages" do |nav| %>
+                      <%= nav.with_toolbar do |toolbar| %>
+                        <% toolbar.with_section padded: true do %>
+                          <h4 class="pt-1"><%= @config.page_collection_label %></h4>
+                        <% end %>
+                        <% toolbar.with_section align: :right, padded: false do %>
+                          <%= lookbook_render :button_group, size: :xs do |group| %>
+                            <% group.with_button icon: :minus_square,
+                              tooltip: "Collapse all",
+                              "x-on:click": "closeAll" %>
+                          <% end %>
+                        <% end %>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/config/app.yml
+++ b/config/app.yml
@@ -10,6 +10,7 @@ shared:
   preview_inspector:
     main_panels: [preview, output]
     drawer_panels: [source, notes, params, "*"]
+    sidebar_panels: [previews, pages]
   preview_embeds:
     enabled: true
     policy: SAMEORIGIN

--- a/docs/src/_data/config_options.yml
+++ b/docs/src/_data/config_options.yml
@@ -50,6 +50,12 @@ previews:
     example: config.lookbook.preview_inspector.drawer_panels = [:notes, :params]
     description: List of panels to display in the preview inspector
 
+  - name: preview_inspector.sidebar_panels
+    types: Array
+    default: '[:previews, :pages]'
+    example: config.lookbook.preview_inspector.sidebar_panels = [:pages, :previews]
+    description: Controls the order and availability of the sidebar navigation panels.
+
   - name: preview_embeds.enabled
     types: Boolean
     default: "true"

--- a/docs/src/_guide/ui/navigation.md
+++ b/docs/src/_guide/ui/navigation.md
@@ -29,6 +29,16 @@ title: Navigation
   ```
 <% end %>
 
+<%= render section("Sections order", id: "sections-order") do |s| %>
+  
+  To change the order of the navigation sections in the sidebar, use the `preview_inspector.sidebar_panels` config option: 
+
+  ```ruby
+  # Display pages before previews in the sidebar
+  config.lookbook.preview_inspector.sidebar_panels = [:pages, :previews]
+  ```
+<% end %>
+
 <%= render section("Scenario order", id: "scenario-order") do |s| %>
   By default scenarios are listed in the navigation in the order in which they are defined in the preview class.
 


### PR DESCRIPTION
Adds a `preview_inspector.sidebar_panels` config option that allows for the reordering (or omitting) of section panels in the Lookbook sidebar.

  ```ruby
  config.lookbook.preview_inspector.sidebar_panels = [:pages, :previews]
  ```

The default value is `[:previews, :pages]`.