### PR TITLE
Ensure `assigns` are handled correctly when rendering previews

### DIFF
--- a/lib/lookbook/preview.rb
+++ b/lib/lookbook/preview.rb
@@ -11,6 +11,7 @@ module Lookbook
           template: args[:template] || Lookbook.config.preview_template,
           args: args,
           locals: args[:locals] || {},
+          assigns: args[:assigns] || {},
           block: block
         }
       else

--- a/lib/lookbook/preview_controller_actions.rb
+++ b/lib/lookbook/preview_controller_actions.rb
@@ -18,6 +18,7 @@ module Lookbook
         locals = @render_args[:locals]
         opts = {}
         opts[:layout] = nil
+        opts[:assigns] = @render_args[:assigns] || {}
         opts[:locals] = locals if locals.present?
 
         rendered = render_to_string(template, **opts)


### PR DESCRIPTION
Fixes the bug outlined in #555 caused by template `assigns` not being passed through when rendering previews.