### PR TITLE
add safe guard for headers["X-Frame-Options"].upcase

### DIFF
--- a/app/controllers/lookbook/previews_controller.rb
+++ b/app/controllers/lookbook/previews_controller.rb
@@ -68,7 +68,7 @@ module Lookbook
 
     def permit_framing
       headers["X-Frame-Options"] = Lookbook.config.preview_embeds.policy if embedded?
-      headers["X-Frame-Options"] = "SAMEORIGIN" if headers["X-Frame-Options"].upcase == "DENY"
+      headers["X-Frame-Options"] = "SAMEORIGIN" if headers["X-Frame-Options"]&.upcase == "DENY"
     end
   end
 end


### PR DESCRIPTION
since upgrading to 2.20 I had an error coming from the preview controller

see for details https://github.com/ViewComponent/lookbook/issues/549#issuecomment-1829469384

