### PR TITLE
Allow disabling of error handling

### DIFF
--- a/app/controllers/lookbook/application_controller.rb
+++ b/app/controllers/lookbook/application_controller.rb
@@ -57,6 +57,8 @@ module Lookbook
     end
 
     def handle_error(err)
+      raise err if Lookbook.config.preview_disable_error_handling
+
       @error = err.is_a?(Lookbook::Error) ? err : Lookbook::Error.new(original: err)
       @status_code = get_status_code(err)
 

--- a/config/app.yml
+++ b/config/app.yml
@@ -23,6 +23,7 @@ shared:
   preview_disable_action_view_annotations: true
   preview_type_default: view_component
   preview_sort_scenarios: false
+  preview_disable_error_handling: false
 
   page_collection_label: "Pages"
   page_nav_filter: false

--- a/lib/lookbook/stores/config_store.rb
+++ b/lib/lookbook/stores/config_store.rb
@@ -59,6 +59,10 @@ module Lookbook
       store[:highlighter_options].merge!(options.to_h)
     end
 
+    def preview_disable_error_handling=(value)
+      store[:preview_disable_error_handling] = value
+    end
+
     def ui_theme=(name)
       name = name.to_s
       if Theme.valid_theme?(name)


### PR DESCRIPTION
Per issue #528
Allow opting out of catching errors in the application controller. Allows usage of web_console, better_errors, and other solutions.